### PR TITLE
Add Japanese and Korean README, docs translations, and language links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Extracted from npm package `@anthropic-ai/claude-code` version **2.1.88**.
 > The published package ships a single bundled `cli.js` (~12MB). The `src/` directory in this repo contains the **unbundled TypeScript source** extracted from the npm tarball.
 
-**Language**: **English** | [中文](README_CN.md)
+**Language**: **English** | [中文](README_CN.md) | [한국어](README_KR.md) | [日本語](README_JA.md)
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Deep Analysis Reports (`docs/`)
 
-Source code analysis reports derived from decompiled v2.1.88. Bilingual (EN/ZH).
+Source code analysis reports derived from decompiled v2.1.88. Quadrilingual (EN/JA/KO/ZH).
 
 ```
 docs/
@@ -32,6 +32,20 @@ docs/
 │   ├── [03-undercover-mode.md]                # Undercover Mode — hiding AI authorship in open-source repos
 │   ├── [04-remote-control-and-killswitches.md]# Remote Control — managed settings, killswitches, model overrides
 │   └── [05-future-roadmap.md]                 # Future Roadmap — Numbat, KAIROS, voice mode, unreleased tools
+│
+├── ja/                                        # 日本語
+│   ├── [01-テレメトリとプライバシー.md]          # テレメトリとプライバシー — 収集項目、無効化不可の理由
+│   ├── [02-隠し機能とコードネーム.md]           # 隠し機能 — モデルコードネーム、feature flag、内部/外部ユーザーの違い
+│   ├── [03-アンダーカバーモード.md]             # アンダーカバーモード — オープンソースでのAI著作隠匿
+│   ├── [04-リモート制御とキルスイッチ.md]       # リモート制御 — 管理設定、キルスイッチ、モデルオーバーライド
+│   └── [05-今後のロードマップ.md]               # 今後のロードマップ — Numbat、KAIROS、音声モード、未公開ツール
+│
+├── ko/                                        # 한국어
+│   ├── [01-텔레메트리와-프라이버시.md]          # 텔레메트리 및 프라이버시 — 수집 항목, 비활성화 불가 이유
+│   ├── [02-숨겨진-기능과-코드네임.md]          # 숨겨진 기능 — 모델 코드네임, feature flag, 내부/외부 사용자 차이
+│   ├── [03-언더커버-모드.md]                   # 언더커버 모드 — 오픈소스에서 AI 저작 은폐
+│   ├── [04-원격-제어와-킬스위치.md]            # 원격 제어 — 관리 설정, 킬스위치, 모델 오버라이드
+│   └── [05-향후-로드맵.md]                     # 향후 로드맵 — Numbat, KAIROS, 음성 모드, 미공개 도구
 │
 └── zh/                                        # 中文
     ├── [01-遥测与隐私分析.md]                    # 遥测与隐私 — 收集了什么，为什么无法退出

--- a/README_CN.md
+++ b/README_CN.md
@@ -5,7 +5,7 @@
 > 从 npm 包 `@anthropic-ai/claude-code` **2.1.88** 版本中提取。
 > 发布的包只有一个打包后的 `cli.js`（~12MB）。本仓库的 `src/` 目录包含从 npm 包中解包的 **TypeScript 源码**。
 
-**语言**: [English](README.md) | **中文**
+**语言**: [English](README.md) | **中文** | [한국어](README_KR.md) | [日本語](README_JA.md)
 
 ---
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,324 @@
+# Claude Code v2.1.88 — ソースコード分析
+
+> **免責事項**: 本リポジトリのすべてのソースコードは **AnthropicおよびClaude** の知的財産です。本リポジトリは技術研究、学習、教育目的の交流のためにのみ提供されます。**商用利用は厳禁です。** いかなる個人、機関、団体も、本コンテンツを商業目的、営利活動、違法行為、その他の無許可の用途に使用することはできません。本コンテンツがお客様の法的権利、知的財産権、その他の利益を侵害する場合は、ご連絡いただければ直ちに確認・削除いたします。
+
+> npmパッケージ `@anthropic-ai/claude-code` **2.1.88** バージョンから抽出。
+> 配布パッケージはバンドルされた単一の `cli.js`（約12MB）のみを含む。本リポジトリの `src/` ディレクトリにはnpmターボールから抽出した**バンドル前のTypeScriptソース**が格納されている。
+
+**言語**: [English](README.md) | [中文](README_CN.md) | [한국어](README_KR.md) | **日本語**
+
+---
+
+## 目次
+
+- [詳細分析レポート (`docs/`)](#詳細分析レポート-docs) — テレメトリ、コードネーム、アンダーカバーモード、リモート制御、今後のロードマップ
+- [欠損モジュール案内](#欠損モジュール案内108モジュール) — feature gateにより除去された108モジュール
+- [アーキテクチャ概要](#アーキテクチャ概要) — エントリポイント → クエリエンジン → ツール/サービス/状態
+- [ビルド案内](#ビルド案内) — 直接コンパイルできない理由
+
+---
+
+## 詳細分析レポート (`docs/`)
+
+v2.1.88デコンパイルソースコードに基づく分析レポート。英語/中国語/韓国語/日本語の4言語で提供。
+
+```
+docs/
+├── en/                                        # English
+│   ├── [01-telemetry-and-privacy.md]          # Telemetry & Privacy — what's collected, why you can't opt out
+│   ├── [02-hidden-features-and-codenames.md]  # Codenames (Capybara/Tengu/Numbat), feature flags, internal vs external
+│   ├── [03-undercover-mode.md]                # Undercover Mode — hiding AI authorship in open-source repos
+│   ├── [04-remote-control-and-killswitches.md]# Remote Control — managed settings, killswitches, model overrides
+│   └── [05-future-roadmap.md]                 # Future Roadmap — Numbat, KAIROS, voice mode, unreleased tools
+│
+├── ja/                                        # 日本語
+│   ├── [01-テレメトリとプライバシー.md]          # テレメトリとプライバシー — 収集項目、無効化不可の理由
+│   ├── [02-隠し機能とコードネーム.md]           # 隠し機能 — モデルコードネーム、feature flag、内部/外部ユーザーの違い
+│   ├── [03-アンダーカバーモード.md]             # アンダーカバーモード — オープンソースでのAI著作隠匿
+│   ├── [04-リモート制御とキルスイッチ.md]       # リモート制御 — 管理設定、キルスイッチ、モデルオーバーライド
+│   └── [05-今後のロードマップ.md]               # 今後のロードマップ — Numbat、KAIROS、音声モード、未公開ツール
+│
+├── ko/                                        # 한국어
+│   ├── [01-텔레메트리와-프라이버시.md]          # 텔레메트리 및 프라이버시 — 수집 항목, 비활성화 불가 이유
+│   ├── [02-숨겨진-기능과-코드네임.md]          # 숨겨진 기능 — 모델 코드네임, feature flag, 내부/외부 사용자 차이
+│   ├── [03-언더커버-모드.md]                   # 언더커버 모드 — 오픈소스에서 AI 저작 은폐
+│   ├── [04-원격-제어와-킬스위치.md]            # 원격 제어 — 관리 설정, 킬스위치, 모델 오버라이드
+│   └── [05-향후-로드맵.md]                     # 향후 로드맵 — Numbat, KAIROS, 음성 모드, 미공개 도구
+│
+└── zh/                                        # 中文
+    ├── [01-遥测与隐私分析.md]                    # 遥测与隐私 — 收集了什么，为什么无法退出
+    ├── [02-隐藏功能与模型代号.md]                # 隐藏功能 — 模型代号，feature flag，内外用户差异
+    ├── [03-卧底模式分析.md]                     # 卧底模式 — 在开源项目中隐藏 AI 身份
+    ├── [04-远程控制与紧急开关.md]                # 远程控制 — 托管设置，紧急开关，模型覆盖
+    └── [05-未来路线图.md]                       # 未来路线图 — Numbat，KAIROS，语音模式，未上线工具
+```
+
+> ファイル名をクリックすると該当レポートに移動します。
+
+| # | テーマ | 主要発見 | リンク |
+|---|--------|---------|------|
+| 01 | **テレメトリとプライバシー** | 二層分析パイプライン（1P→Anthropic、Datadog）。環境フィンガープリント、プロセスメトリクス、全イベントにセッション/ユーザーID。**ユーザー向け無効化設定なし。** `OTEL_LOG_TOOL_DETAILS=1` で全ツール入力記録可能。 | [EN](docs/en/01-telemetry-and-privacy.md) · [日本語](docs/ja/01-テレメトリとプライバシー.md) |
+| 02 | **隠し機能とコードネーム** | 動物コードネーム体系（Capybara v8、Tengu、Fennec→Opus 4.6、**Numbat** 次期）。Feature flagにランダム単語ペアで目的を難読化。内部ユーザーは優遇プロンプトと検証エージェントを利用可能。隠しコマンド: `/btw`、`/stickers`。 | [EN](docs/en/02-hidden-features-and-codenames.md) · [日本語](docs/ja/02-隠し機能とコードネーム.md) |
+| 03 | **アンダーカバーモード** | Anthropic社員は公開リポジトリで自動的にアンダーカバーモードに突入。モデルへの指示: **「正体を明かすな」** — 全AI帰属表示を除去し、人間が書いたようにコミット。**強制無効化オプションなし。** | [EN](docs/en/03-undercover-mode.md) · [日本語](docs/ja/03-アンダーカバーモード.md) |
+| 04 | **リモート制御とキルスイッチ** | 1時間ごとに `/api/claude_code/settings` をポーリング。危険な変更時にブロッキングダイアログ — **拒否＝アプリ終了**。6以上のキルスイッチ（パーミッションバイパス、Fastモード、音声モード、分析シンク）。GrowthBookで同意なくユーザー動作変更可能。 | [EN](docs/en/04-remote-control-and-killswitches.md) · [日本語](docs/ja/04-リモート制御とキルスイッチ.md) |
+| 05 | **今後のロードマップ** | **Numbat** コードネーム確認。Opus 4.7 / Sonnet 4.8開発中。**KAIROS** ＝ 完全自律エージェントモード、`<tick>`ハートビート、プッシュ通知、PR購読。音声モード（push-to-talk）準備完了。未公開ツール17個発見。 | [EN](docs/en/05-future-roadmap.md) · [日本語](docs/ja/05-今後のロードマップ.md) |
+
+---
+
+## 欠損モジュール案内（108モジュール）
+
+> **このソースは不完全である。** `feature()` ゲートで分岐した108モジュールがnpmパッケージに**含まれていない**。
+> これらはAnthropicの内部モノレポにのみ存在し、コンパイル時にデッドコード除去される。
+> `cli.js`、`sdk-tools.d.ts`、その他配布アーティファクトから**復元できない**。
+
+### Anthropic内部コード（約70モジュール、未公開）
+
+npmパッケージにソースファイルが一切ないモジュール。Anthropic内部インフラに該当する。
+
+<details>
+<summary>全リスト展開</summary>
+
+| Module | 用途 | Feature Gate |
+|--------|------|-------------|
+| `daemon/main.js` | バックグラウンドデーモン管理 | `DAEMON` |
+| `daemon/workerRegistry.js` | デーモンワーカーレジストリ | `DAEMON` |
+| `proactive/index.js` | 先行通知システム | `PROACTIVE` |
+| `contextCollapse/index.js` | コンテキスト縮小サービス（実験的） | `CONTEXT_COLLAPSE` |
+| `contextCollapse/operations.js` | 縮小操作 | `CONTEXT_COLLAPSE` |
+| `contextCollapse/persist.js` | 縮小永続化 | `CONTEXT_COLLAPSE` |
+| `skillSearch/featureCheck.js` | リモートスキル機能検査 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/remoteSkillLoader.js` | リモートスキルローダー | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/remoteSkillState.js` | リモートスキル状態 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/telemetry.js` | スキル検索テレメトリ | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/localSearch.js` | ローカルスキル検索 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/prefetch.js` | スキルプリフェッチ | `EXPERIMENTAL_SKILL_SEARCH` |
+| `coordinator/workerAgent.js` | マルチエージェントコーディネーターワーカー | `COORDINATOR_MODE` |
+| `bridge/peerSessions.js` | ブリッジピアセッション管理 | `BRIDGE_MODE` |
+| `assistant/index.js` | KAIROSアシスタントモード | `KAIROS` |
+| `assistant/AssistantSessionChooser.js` | アシスタントセッション選択 | `KAIROS` |
+| `compact/reactiveCompact.js` | リアクティブコンテキスト圧縮 | `CACHED_MICROCOMPACT` |
+| `compact/snipCompact.js` | スニップベース圧縮 | `HISTORY_SNIP` |
+| `compact/snipProjection.js` | スニッププロジェクション | `HISTORY_SNIP` |
+| `compact/cachedMCConfig.js` | キャッシュマイクロ圧縮設定 | `CACHED_MICROCOMPACT` |
+| `sessionTranscript/sessionTranscript.js` | セッショントランスクリプトサービス | `TRANSCRIPT_CLASSIFIER` |
+| `commands/agents-platform/index.js` | 内部エージェントプラットフォーム | `ant`（内部） |
+| `commands/assistant/index.js` | アシスタントコマンド | `KAIROS` |
+| `commands/buddy/index.js` | Buddyシステム通知 | `BUDDY` |
+| `commands/fork/index.js` | Forkサブエージェントコマンド | `FORK_SUBAGENT` |
+| `commands/peers/index.js` | マルチピアコマンド | `BRIDGE_MODE` |
+| `commands/proactive.js` | 先行コマンド | `PROACTIVE` |
+| `commands/remoteControlServer/index.js` | リモート制御サーバー | `DAEMON` + `BRIDGE_MODE` |
+| `commands/subscribe-pr.js` | GitHub PR購読 | `KAIROS_GITHUB_WEBHOOKS` |
+| `commands/torch.js` | 内部デバッグツール | `TORCH` |
+| `commands/workflows/index.js` | ワークフローコマンド | `WORKFLOW_SCRIPTS` |
+| `jobs/classifier.js` | 内部タスク分類器 | `TEMPLATES` |
+| `memdir/memoryShapeTelemetry.js` | メモリ形状テレメトリ | `MEMORY_SHAPE_TELEMETRY` |
+| `services/sessionTranscript/sessionTranscript.js` | セッショントランスクリプト | `TRANSCRIPT_CLASSIFIER` |
+| `tasks/LocalWorkflowTask/LocalWorkflowTask.js` | ローカルワークフロータスク | `WORKFLOW_SCRIPTS` |
+| `protectedNamespace.js` | 内部ネームスペースガード | `ant`（内部） |
+| `protectedNamespace.js` (envUtils) | 保護ネームスペースランタイム | `ant`（内部） |
+| `coreTypes.generated.js` | 生成されたコアタイプ | `ant`（内部） |
+| `devtools.js` | 内部開発ツール | `ant`（内部） |
+| `attributionHooks.js` | 内部帰属フック | `COMMIT_ATTRIBUTION` |
+| `systemThemeWatcher.js` | システムテーマウォッチャー | `AUTO_THEME` |
+| `udsClient.js` / `udsMessaging.js` | UDSメッセージクライアント | `UDS_INBOX` |
+
+</details>
+
+### Feature-Gatedツール（約20モジュール）
+
+型シグネチャは存在するが、実装がコンパイル時に除去されたツール。
+
+<details>
+<summary>全リスト展開</summary>
+
+| Tool | 用途 | Feature Gate |
+|------|------|-------------|
+| `REPLTool` | インタラクティブREPL（VMサンドボックス） | `ant`（内部） |
+| `SnipTool` | コンテキストスニッピング | `HISTORY_SNIP` |
+| `SleepTool` | エージェントループ内スリープ/遅延 | `PROACTIVE` / `KAIROS` |
+| `MonitorTool` | MCPモニタリング | `MONITOR_TOOL` |
+| `OverflowTestTool` | オーバーフローテスト | `OVERFLOW_TEST_TOOL` |
+| `WorkflowTool` | ワークフロー実行 | `WORKFLOW_SCRIPTS` |
+| `WebBrowserTool` | ブラウザ自動化 | `WEB_BROWSER_TOOL` |
+| `TerminalCaptureTool` | ターミナルキャプチャ | `TERMINAL_PANEL` |
+| `TungstenTool` | 内部パフォーマンス監視 | `ant`（内部） |
+| `VerifyPlanExecutionTool` | 計画実行検証 | `CLAUDE_CODE_VERIFY_PLAN` |
+| `SendUserFileTool` | ユーザーへのファイル送信 | `KAIROS` |
+| `SubscribePRTool` | GitHub PR購読 | `KAIROS_GITHUB_WEBHOOKS` |
+| `SuggestBackgroundPRTool` | バックグラウンドPR提案 | `KAIROS` |
+| `PushNotificationTool` | プッシュ通知 | `KAIROS` |
+| `CtxInspectTool` | コンテキスト検査 | `CONTEXT_COLLAPSE` |
+| `ListPeersTool` | アクティブピア一覧 | `UDS_INBOX` |
+| `DiscoverSkillsTool` | スキル探索 | `EXPERIMENTAL_SKILL_SEARCH` |
+
+</details>
+
+### テキスト/プロンプトリソース（約6ファイル）
+
+| File | 用途 |
+|------|------|
+| `yolo-classifier-prompts/auto_mode_system_prompt.txt` | autoモード分類器システムプロンプト |
+| `yolo-classifier-prompts/permissions_anthropic.txt` | Anthropic内部権限プロンプト |
+| `yolo-classifier-prompts/permissions_external.txt` | 外部ユーザー権限プロンプト |
+| `verify/SKILL.md` | 検証スキルドキュメント |
+| `verify/examples/cli.md` | CLI検証例 |
+| `verify/examples/server.md` | サーバー検証例 |
+
+### 欠損の理由
+
+```
+  Anthropic内部モノレポ                  配布npmパッケージ
+  ──────────────────────               ─────────────────────
+  feature('DAEMON') → true    ──ビルド──→   feature('DAEMON') → false
+  ↓                                         ↓
+  daemon/main.js  ← 含む        ──バンドル──→  daemon/main.js  ← 除去 (DCE)
+  tools/REPLTool  ← 含む        ──バンドル──→  tools/REPLTool  ← 除去 (DCE)
+  proactive/      ← 含む        ──バンドル──→  （参照のみ、src/に不在）
+```
+
+  Bunの `feature()` は**コンパイル時組込関数**:
+  - Anthropic内部ビルドで `true` 返却 → コードがバンドルに含まれる
+  - 配布ビルドで `false` 返却 → デッドコード除去
+  - 108モジュールが配布アーティファクトに存在しない
+
+---
+
+## 著作権および免責事項
+
+```
+Copyright (c) Anthropic. All rights reserved.
+
+本リポジトリのすべてのソースコードはAnthropicおよびClaudeの知的財産です。
+本リポジトリは技術研究および教育目的でのみ提供されます。商用利用は禁止です。
+
+著作権者として本リポジトリがお客様の権利を侵害すると判断される場合は、
+リポジトリ所有者にご連絡いただければ直ちに削除いたします。
+```
+
+---
+
+## 統計
+
+| 項目 | 数量 |
+|------|------|
+| ソースファイル (.ts/.tsx) | 約1,884 |
+| コード行数 | 約512,664 |
+| 最大単一ファイル | `query.ts`（約785KB） |
+| 組込ツール | 約40以上 |
+| スラッシュコマンド | 約80以上 |
+| 依存関係 (node_modules) | 約192パッケージ |
+| ランタイム | Bun（Node.js >= 18バンドルにコンパイル） |
+
+---
+
+## エージェントモード
+
+```
+                    コアループ
+                    ========
+
+    ユーザー --> messages[] --> Claude API --> レスポンス
+                                          |
+                                stop_reason == "tool_use"?
+                               /                          \
+                             はい                         いいえ
+                              |                             |
+                        ツール実行                      テキスト返却
+                        tool_result追加
+                        ループ再突入 -----------------> messages[]
+
+
+    これが最小のエージェントループである。Claude Codeはこのループの上に
+    プロダクショングレードのハーネスをラップする: 権限、ストリーミング、
+    並行性、圧縮、サブエージェント、永続化、MCP。
+```
+
+---
+
+## ディレクトリ参照
+
+```
+src/
+├── main.tsx                 # REPLブートストラップ、4,683行
+├── QueryEngine.ts           # SDK/headlessクエリライフサイクルエンジン
+├── query.ts                 # メインエージェントループ（785KB、最大ファイル）
+├── Tool.ts                  # ツールインターフェース + buildToolファクトリ
+├── Task.ts                  # タスクタイプ、ID、状態ベースクラス
+├── tools.ts                 # ツール登録、プリセット、フィルタリング
+├── commands.ts              # スラッシュコマンド定義
+├── context.ts               # ユーザー入力コンテキスト
+├── cost-tracker.ts          # APIコスト累積
+├── setup.ts                 # 初回実行セットアップフロー
+│
+├── bridge/                  # Claude Desktop / リモートブリッジ
+│   ├── bridgeMain.ts        #   セッションライフサイクルマネージャ
+│   ├── bridgeApi.ts         #   HTTPクライアント
+│   ├── bridgeConfig.ts      #   接続設定
+│   ├── bridgeMessaging.ts   #   メッセージリレー
+│   ├── sessionRunner.ts     #   プロセススポーン
+│   ├── jwtUtils.ts          #   JWTリフレッシュ
+│   ├── workSecret.ts        #   認証トークン
+│   └── capacityWake.ts      #   容量ベースウェイク
+│
+├── cli/                     # CLIインフラ
+│   ├── handlers/            #   コマンドハンドラ
+│   └── transports/          #   I/Oトランスポート（stdio, structured）
+│
+├── commands/                # 約80スラッシュコマンド
+├── components/              # React/InkターミナルUI
+├── entrypoints/             # アプリエントリポイント
+├── hooks/                   # React hooks
+├── services/                # ビジネスロジック層
+├── state/                   # アプリ状態
+├── tasks/                   # タスク実装
+├── tools/                   # 40以上のツール実装
+├── types/                   # 型定義
+├── utils/                   # ユーティリティ（最大ディレクトリ）
+└── vendor/                  # ネイティブモジュールソーススタブ
+```
+
+---
+
+## アーキテクチャ概要
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         エントリ層                                   │
+│  cli.tsx ──> main.tsx ──> REPL.tsx（インタラクティブ）               │
+│                     └──> QueryEngine.ts（headless/SDK）              │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                       クエリエンジン                                  │
+│  submitMessage(prompt) ──> AsyncGenerator<SDKMessage>               │
+│    ├── fetchSystemPromptParts()    ──> システムプロンプト組立        │
+│    ├── processUserInput()          ──> /コマンド処理                 │
+│    ├── query()                     ──> メインエージェントループ      │
+│    │     ├── StreamingToolExecutor ──> 並列ツール実行               │
+│    │     ├── autoCompact()         ──> コンテキスト圧縮             │
+│    │     └── runTools()            ──> ツールオーケストレーション    │
+│    └── yield SDKMessage            ──> コンシューマにストリーミング  │
+└──────────────────────────────┬──────────────────────────────────────┘
+```
+
+---
+
+## ビルド案内
+
+このソースは**本リポジトリから直接コンパイルできない**:
+
+- `tsconfig.json`、ビルドスクリプト、Bunバンドラー設定がない
+- `feature()` 呼び出しはBunコンパイル時組込関数 — バンドリング時に解決される
+- `MACRO.VERSION` はビルド時に注入される
+- `process.env.USER_TYPE === 'ant'` 分岐はAnthropic内部用
+- コンパイル済み `cli.js` は自己完結型12MBバンドル、Node.js >= 18のみ必要
+
+**ビルドの詳細は [QUICKSTART.md](QUICKSTART.md) を参照。**
+
+---
+
+## ライセンス
+
+本リポジトリのすべてのソースコードは **AnthropicおよびClaude** の著作物です。本リポジトリは技術研究および教育目的でのみ提供されます。完全なライセンス条項は元のnpmパッケージを参照してください。

--- a/README_KR.md
+++ b/README_KR.md
@@ -1,0 +1,317 @@
+# Claude Code v2.1.88 — 소스 코드 분석
+
+> **면책 조항**: 이 저장소의 모든 소스 코드는 **Anthropic과 Claude**의 지적 재산입니다. 이 저장소는 기술 연구, 학습, 교육 목적의 교류를 위해서만 제공됩니다. **상업적 사용은 엄격히 금지됩니다.** 어떠한 개인, 기관, 단체도 이 콘텐츠를 상업적 목적, 영리 활동, 불법 활동 또는 기타 무단 사용에 활용할 수 없습니다. 본 콘텐츠가 귀하의 법적 권리, 지적 재산권 또는 기타 이익을 침해하는 경우, 연락 주시면 즉시 확인 후 삭제 조치하겠습니다.
+
+> npm 패키지 `@anthropic-ai/claude-code` **2.1.88** 버전에서 추출.
+> 배포 패키지는 단일 번들 `cli.js`(~12MB)만 포함한다. 이 저장소의 `src/` 디렉터리에는 npm 타르볼에서 추출한 **번들 전 TypeScript 소스**가 들어 있다.
+
+**언어**: [English](README.md) | [中文](README_CN.md) | **한국어** | [日本語](README_JA.md)
+
+---
+
+## 목차
+
+- [심층 분석 보고서 (`docs/`)](#심층-분석-보고서-docs) — 텔레메트리, 코드네임, 언더커버 모드, 원격 제어, 향후 로드맵
+- [누락 모듈 안내](#누락-모듈-안내108개-모듈) — feature gate로 제거된 108개 모듈
+- [아키텍처 개요](#아키텍처-개요) — 진입점 → 쿼리 엔진 → 도구/서비스/상태
+- [빌드 안내](#빌드-안내) — 직접 컴파일이 불가능한 이유
+
+---
+
+## 심층 분석 보고서 (`docs/`)
+
+v2.1.88 디컴파일 소스 코드 기반 분석 보고서. 영어/중국어/한국어 3개 국어 제공.
+
+```
+docs/
+├── en/                                        # English
+│   ├── [01-telemetry-and-privacy.md]          # Telemetry & Privacy — what's collected, why you can't opt out
+│   ├── [02-hidden-features-and-codenames.md]  # Codenames (Capybara/Tengu/Numbat), feature flags, internal vs external
+│   ├── [03-undercover-mode.md]                # Undercover Mode — hiding AI authorship in open-source repos
+│   ├── [04-remote-control-and-killswitches.md]# Remote Control — managed settings, killswitches, model overrides
+│   └── [05-future-roadmap.md]                 # Future Roadmap — Numbat, KAIROS, voice mode, unreleased tools
+│
+├── ko/                                        # 한국어
+│   ├── [01-텔레메트리와-프라이버시.md]          # 텔레메트리 및 프라이버시 — 수집 항목, 비활성화 불가 이유
+│   ├── [02-숨겨진-기능과-코드네임.md]          # 숨겨진 기능 — 모델 코드네임, feature flag, 내부/외부 사용자 차이
+│   ├── [03-언더커버-모드.md]                   # 언더커버 모드 — 오픈소스에서 AI 저작 은폐
+│   ├── [04-원격-제어와-킬스위치.md]            # 원격 제어 — 관리 설정, 킬스위치, 모델 오버라이드
+│   └── [05-향후-로드맵.md]                     # 향후 로드맵 — Numbat, KAIROS, 음성 모드, 미공개 도구
+│
+└── zh/                                        # 中文
+    ├── [01-遥测与隐私分析.md]                    # 遥测与隐私 — 收集了什么，为什么无法退出
+    ├── [02-隐藏功能与模型代号.md]                # 隐藏功能 — 模型代号，feature flag，内外用户差异
+    ├── [03-卧底模式分析.md]                     # 卧底模式 — 在开源项目中隐藏 AI 身份
+    ├── [04-远程控制与紧急开关.md]                # 远程控制 — 托管设置，紧急开关，模型覆盖
+    └── [05-未来路线图.md]                       # 未来路线图 — Numbat，KAIROS，语音模式，未上线工具
+```
+
+> 파일명을 클릭하면 해당 보고서로 이동합니다.
+
+| # | 주제 | 핵심 발견 | 링크 |
+|---|------|----------|------|
+| 01 | **텔레메트리 및 프라이버시** | 이중 분석 파이프라인 (1P→Anthropic, Datadog). 환경 핑거프린트, 프로세스 메트릭, 모든 이벤트에 세션/사용자 ID 포함. **사용자 대상 비활성화 설정 없음.** `OTEL_LOG_TOOL_DETAILS=1`로 전체 도구 입력 기록 가능. | [EN](docs/en/01-telemetry-and-privacy.md) · [한국어](docs/ko/01-텔레메트리와-프라이버시.md) · [中文](docs/zh/01-遥测与隐私分析.md) |
+| 02 | **숨겨진 기능과 코드네임** | 동물 코드네임 체계 (Capybara v8, Tengu, Fennec→Opus 4.6, **Numbat** 차기). Feature flag에 무작위 단어 조합으로 목적 난독화. 내부 사용자는 더 나은 프롬프트와 검증 에이전트 제공. 숨겨진 명령어: `/btw`, `/stickers`. | [EN](docs/en/02-hidden-features-and-codenames.md) · [한국어](docs/ko/02-숨겨진-기능과-코드네임.md) · [中文](docs/zh/02-隐藏功能与模型代号.md) |
+| 03 | **언더커버 모드** | Anthropic 직원은 공개 저장소에서 자동으로 언더커버 모드 진입. 모델 지시: **"정체를 들키지 마라"** — 모든 AI 저작 표시를 제거하고, 사람이 작성한 것처럼 커밋. **강제 비활성화 옵션 없음.** | [EN](docs/en/03-undercover-mode.md) · [한국어](docs/ko/03-언더커버-모드.md) · [中文](docs/zh/03-卧底模式分析.md) |
+| 04 | **원격 제어 및 킬스위치** | 1시간마다 `/api/claude_code/settings` 폴링. 위험 변경 시 차단 다이얼로그 — **거부 = 앱 종료**. 6개 이상 킬스위치 (권한 우회, fast 모드, 음성 모드, 분석 싱크). GrowthBook으로 동의 없이 사용자 동작 변경 가능. | [EN](docs/en/04-remote-control-and-killswitches.md) · [한국어](docs/ko/04-원격-제어와-킬스위치.md) · [中文](docs/zh/04-远程控制与紧急开关.md) |
+| 05 | **향후 로드맵** | **Numbat** 코드네임 확인. Opus 4.7 / Sonnet 4.8 개발 중. **KAIROS** = 완전 자율 에이전트 모드, `<tick>` 하트비트, 푸시 알림, PR 구독. 음성 모드(push-to-talk) 준비 완료. 미공개 도구 17개 발견. | [EN](docs/en/05-future-roadmap.md) · [한국어](docs/ko/05-향후-로드맵.md) · [中文](docs/zh/05-未来路线图.md) |
+
+---
+
+## 누락 모듈 안내（108개 모듈）
+
+> **이 소스는 불완전하다.** `feature()` 게이트로 분기된 108개 모듈이 npm 패키지에 **포함되어 있지 않다**.
+> 이 모듈들은 Anthropic 내부 모노레포에만 존재하며, 컴파일 시 데드 코드 제거된다.
+> `cli.js`, `sdk-tools.d.ts` 또는 기타 배포 아티팩트에서 **복구할 수 없다**.
+
+### Anthropic 내부 코드 (~70개 모듈, 미공개)
+
+npm 패키지에 소스 파일이 전혀 없는 모듈이다. Anthropic 내부 인프라에 해당한다.
+
+<details>
+<summary>전체 목록 펼치기</summary>
+
+| Module | 용도 | Feature Gate |
+|--------|------|-------------|
+| `daemon/main.js` | 백그라운드 데몬 관리자 | `DAEMON` |
+| `daemon/workerRegistry.js` | 데몬 워커 레지스트리 | `DAEMON` |
+| `proactive/index.js` | 선제적 알림 시스템 | `PROACTIVE` |
+| `contextCollapse/index.js` | 컨텍스트 축소 서비스 (실험적) | `CONTEXT_COLLAPSE` |
+| `contextCollapse/operations.js` | 축소 연산 | `CONTEXT_COLLAPSE` |
+| `contextCollapse/persist.js` | 축소 영속화 | `CONTEXT_COLLAPSE` |
+| `skillSearch/featureCheck.js` | 원격 스킬 기능 검사 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/remoteSkillLoader.js` | 원격 스킬 로더 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/remoteSkillState.js` | 원격 스킬 상태 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/telemetry.js` | 스킬 검색 텔레메트리 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/localSearch.js` | 로컬 스킬 검색 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `skillSearch/prefetch.js` | 스킬 프리페치 | `EXPERIMENTAL_SKILL_SEARCH` |
+| `coordinator/workerAgent.js` | 멀티 에이전트 코디네이터 워커 | `COORDINATOR_MODE` |
+| `bridge/peerSessions.js` | 브릿지 피어 세션 관리 | `BRIDGE_MODE` |
+| `assistant/index.js` | KAIROS 어시스턴트 모드 | `KAIROS` |
+| `assistant/AssistantSessionChooser.js` | 어시스턴트 세션 선택기 | `KAIROS` |
+| `compact/reactiveCompact.js` | 반응형 컨텍스트 압축 | `CACHED_MICROCOMPACT` |
+| `compact/snipCompact.js` | 스닙 기반 압축 | `HISTORY_SNIP` |
+| `compact/snipProjection.js` | 스닙 프로젝션 | `HISTORY_SNIP` |
+| `compact/cachedMCConfig.js` | 캐시 마이크로압축 설정 | `CACHED_MICROCOMPACT` |
+| `sessionTranscript/sessionTranscript.js` | 세션 트랜스크립트 서비스 | `TRANSCRIPT_CLASSIFIER` |
+| `commands/agents-platform/index.js` | 내부 에이전트 플랫폼 | `ant` (내부) |
+| `commands/assistant/index.js` | 어시스턴트 명령 | `KAIROS` |
+| `commands/buddy/index.js` | Buddy 시스템 알림 | `BUDDY` |
+| `commands/fork/index.js` | Fork 서브에이전트 명령 | `FORK_SUBAGENT` |
+| `commands/peers/index.js` | 멀티 피어 명령 | `BRIDGE_MODE` |
+| `commands/proactive.js` | 선제적 명령 | `PROACTIVE` |
+| `commands/remoteControlServer/index.js` | 원격 제어 서버 | `DAEMON` + `BRIDGE_MODE` |
+| `commands/subscribe-pr.js` | GitHub PR 구독 | `KAIROS_GITHUB_WEBHOOKS` |
+| `commands/torch.js` | 내부 디버그 도구 | `TORCH` |
+| `commands/workflows/index.js` | 워크플로우 명령 | `WORKFLOW_SCRIPTS` |
+| `jobs/classifier.js` | 내부 작업 분류기 | `TEMPLATES` |
+| `memdir/memoryShapeTelemetry.js` | 기억 형태 텔레메트리 | `MEMORY_SHAPE_TELEMETRY` |
+| `services/sessionTranscript/sessionTranscript.js` | 세션 트랜스크립트 | `TRANSCRIPT_CLASSIFIER` |
+| `tasks/LocalWorkflowTask/LocalWorkflowTask.js` | 로컬 워크플로우 태스크 | `WORKFLOW_SCRIPTS` |
+| `protectedNamespace.js` | 내부 네임스페이스 가드 | `ant` (내부) |
+| `protectedNamespace.js` (envUtils) | 보호 네임스페이스 런타임 | `ant` (내부) |
+| `coreTypes.generated.js` | 생성된 코어 타입 | `ant` (내부) |
+| `devtools.js` | 내부 개발 도구 | `ant` (내부) |
+| `attributionHooks.js` | 내부 저작 표시 훅 | `COMMIT_ATTRIBUTION` |
+| `systemThemeWatcher.js` | 시스템 테마 감시기 | `AUTO_THEME` |
+| `udsClient.js` / `udsMessaging.js` | UDS 메시지 클라이언트 | `UDS_INBOX` |
+
+</details>
+
+### Feature-Gated 도구 (~20개 모듈)
+
+타입 시그니처는 있으나 구현이 컴파일 시 제거된 도구.
+
+<details>
+<summary>전체 목록 펼치기</summary>
+
+| Tool | 용도 | Feature Gate |
+|------|------|-------------|
+| `REPLTool` | 인터랙티브 REPL (VM 샌드박스) | `ant` (내부) |
+| `SnipTool` | 컨텍스트 잘라내기 | `HISTORY_SNIP` |
+| `SleepTool` | 에이전트 루프 내 슬립/지연 | `PROACTIVE` / `KAIROS` |
+| `MonitorTool` | MCP 모니터링 | `MONITOR_TOOL` |
+| `OverflowTestTool` | 오버플로우 테스트 | `OVERFLOW_TEST_TOOL` |
+| `WorkflowTool` | 워크플로우 실행 | `WORKFLOW_SCRIPTS` |
+| `WebBrowserTool` | 브라우저 자동화 | `WEB_BROWSER_TOOL` |
+| `TerminalCaptureTool` | 터미널 캡처 | `TERMINAL_PANEL` |
+| `TungstenTool` | 내부 성능 모니터링 | `ant` (내부) |
+| `VerifyPlanExecutionTool` | 계획 실행 검증 | `CLAUDE_CODE_VERIFY_PLAN` |
+| `SendUserFileTool` | 사용자에게 파일 전송 | `KAIROS` |
+| `SubscribePRTool` | GitHub PR 구독 | `KAIROS_GITHUB_WEBHOOKS` |
+| `SuggestBackgroundPRTool` | 백그라운드 PR 제안 | `KAIROS` |
+| `PushNotificationTool` | 푸시 알림 | `KAIROS` |
+| `CtxInspectTool` | 컨텍스트 검사 | `CONTEXT_COLLAPSE` |
+| `ListPeersTool` | 활성 피어 목록 | `UDS_INBOX` |
+| `DiscoverSkillsTool` | 스킬 탐색 | `EXPERIMENTAL_SKILL_SEARCH` |
+
+</details>
+
+### 텍스트/프롬프트 리소스 (~6개 파일)
+
+| File | 용도 |
+|------|------|
+| `yolo-classifier-prompts/auto_mode_system_prompt.txt` | auto 모드 분류기 시스템 프롬프트 |
+| `yolo-classifier-prompts/permissions_anthropic.txt` | Anthropic 내부 권한 프롬프트 |
+| `yolo-classifier-prompts/permissions_external.txt` | 외부 사용자 권한 프롬프트 |
+| `verify/SKILL.md` | 검증 스킬 문서 |
+| `verify/examples/cli.md` | CLI 검증 예시 |
+| `verify/examples/server.md` | 서버 검증 예시 |
+
+### 누락 이유
+
+```
+  Anthropic 내부 모노레포               배포 npm 패키지
+  ──────────────────────               ─────────────────────
+  feature('DAEMON') → true    ──빌드──→   feature('DAEMON') → false
+  ↓                                         ↓
+  daemon/main.js  ← 포함        ──번들──→  daemon/main.js  ← 제거 (DCE)
+  tools/REPLTool  ← 포함        ──번들──→  tools/REPLTool  ← 제거 (DCE)
+  proactive/      ← 포함        ──번들──→  (참조만 있고 src/에 없음)
+```
+
+  Bun의 `feature()`는 **컴파일 시점 내장 함수**:
+  - Anthropic 내부 빌드에서 `true` 반환 → 코드가 번들에 포함
+  - 배포 빌드에서 `false` 반환 → 데드 코드 제거
+  - 108개 모듈이 배포 아티팩트에 존재하지 않음
+
+---
+
+## 저작권 및 면책 조항
+
+```
+Copyright (c) Anthropic. All rights reserved.
+
+이 저장소의 모든 소스 코드는 Anthropic과 Claude의 지적 재산입니다.
+본 저장소는 기술 연구 및 교육 목적으로만 제공됩니다. 상업적 사용은 금지됩니다.
+
+저작권자로서 본 저장소가 귀하의 권리를 침해한다고 판단되는 경우,
+저장소 소유자에게 연락 주시면 즉시 삭제하겠습니다.
+```
+
+---
+
+## 통계
+
+| 항목 | 수량 |
+|------|------|
+| 소스 파일 (.ts/.tsx) | ~1,884 |
+| 코드 라인 수 | ~512,664 |
+| 최대 단일 파일 | `query.ts` (~785KB) |
+| 내장 도구 | ~40개 이상 |
+| 슬래시 명령 | ~80개 이상 |
+| 의존성 (node_modules) | ~192개 패키지 |
+| 런타임 | Bun (Node.js >= 18 번들로 컴파일) |
+
+---
+
+## 에이전트 모드
+
+```
+                    코어 루프
+                    ========
+
+    사용자 --> messages[] --> Claude API --> 응답
+                                          |
+                                stop_reason == "tool_use"?
+                               /                          \
+                             예                           아니오
+                              |                             |
+                        도구 실행                        텍스트 반환
+                        tool_result 추가
+                        루프 재진입 -----------------> messages[]
+
+
+    이것이 최소 에이전트 루프이다. Claude Code는 이 루프 위에
+    프로덕션급 하니스를 래핑한다: 권한, 스트리밍, 동시성,
+    압축, 서브에이전트, 영속화 및 MCP.
+```
+
+---
+
+## 디렉터리 참조
+
+```
+src/
+├── main.tsx                 # REPL 부트스트랩, 4,683줄
+├── QueryEngine.ts           # SDK/headless 쿼리 라이프사이클 엔진
+├── query.ts                 # 메인 에이전트 루프 (785KB, 최대 파일)
+├── Tool.ts                  # 도구 인터페이스 + buildTool 팩토리
+├── Task.ts                  # 태스크 타입, ID, 상태 베이스 클래스
+├── tools.ts                 # 도구 등록, 프리셋, 필터링
+├── commands.ts              # 슬래시 명령 정의
+├── context.ts               # 사용자 입력 컨텍스트
+├── cost-tracker.ts          # API 비용 누적
+├── setup.ts                 # 최초 실행 설정 플로우
+│
+├── bridge/                  # Claude Desktop / 원격 브릿지
+│   ├── bridgeMain.ts        #   세션 라이프사이클 매니저
+│   ├── bridgeApi.ts         #   HTTP 클라이언트
+│   ├── bridgeConfig.ts      #   연결 설정
+│   ├── bridgeMessaging.ts   #   메시지 릴레이
+│   ├── sessionRunner.ts     #   프로세스 스폰
+│   ├── jwtUtils.ts          #   JWT 갱신
+│   ├── workSecret.ts        #   인증 토큰
+│   └── capacityWake.ts      #   용량 기반 웨이크
+│
+├── cli/                     # CLI 인프라
+│   ├── handlers/            #   명령 핸들러
+│   └── transports/          #   I/O 전송 (stdio, structured)
+│
+├── commands/                # ~80개 슬래시 명령
+├── components/              # React/Ink 터미널 UI
+├── entrypoints/             # 앱 진입점
+├── hooks/                   # React hooks
+├── services/                # 비즈니스 로직 레이어
+├── state/                   # 앱 상태
+├── tasks/                   # 태스크 구현
+├── tools/                   # 40개 이상 도구 구현
+├── types/                   # 타입 정의
+├── utils/                   # 유틸리티 (최대 디렉터리)
+└── vendor/                  # 네이티브 모듈 소스 스텁
+```
+
+---
+
+## 아키텍처 개요
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         진입 레이어                                  │
+│  cli.tsx ──> main.tsx ──> REPL.tsx (인터랙티브)                     │
+│                     └──> QueryEngine.ts (headless/SDK)              │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                       쿼리 엔진                                      │
+│  submitMessage(prompt) ──> AsyncGenerator<SDKMessage>               │
+│    ├── fetchSystemPromptParts()    ──> 시스템 프롬프트 조립          │
+│    ├── processUserInput()          ──> /명령 처리                    │
+│    ├── query()                     ──> 메인 에이전트 루프            │
+│    │     ├── StreamingToolExecutor ──> 병렬 도구 실행               │
+│    │     ├── autoCompact()         ──> 컨텍스트 압축                │
+│    │     └── runTools()            ──> 도구 오케스트레이션           │
+│    └── yield SDKMessage            ──> 소비자에게 스트리밍           │
+└──────────────────────────────┬──────────────────────────────────────┘
+```
+
+---
+
+## 빌드 안내
+
+이 소스는 **이 저장소에서 직접 컴파일할 수 없다**:
+
+- `tsconfig.json`, 빌드 스크립트, Bun 번들러 설정이 없음
+- `feature()` 호출은 Bun 컴파일 시점 내장 함수 — 번들링 시 해석됨
+- `MACRO.VERSION`은 빌드 시 주입됨
+- `process.env.USER_TYPE === 'ant'` 분기는 Anthropic 내부용
+- 컴파일된 `cli.js`는 자체 완결형 12MB 번들, Node.js >= 18만 필요
+
+**빌드 상세 안내는 [QUICKSTART.md](QUICKSTART.md) 참고.**
+
+---
+
+## 라이선스
+
+이 저장소의 모든 소스 코드는 **Anthropic과 Claude**의 저작물입니다. 본 저장소는 기술 연구 및 교육 목적으로만 제공됩니다. 전체 라이선스 조건은 원본 npm 패키지를 참조하세요.

--- a/docs/ja/01-テレメトリとプライバシー.md
+++ b/docs/ja/01-テレメトリとプライバシー.md
@@ -1,0 +1,124 @@
+# テレメトリおよびプライバシー分析
+
+> Claude Code v2.1.88 デコンパイルソースコード分析に基づく。
+
+## 概要
+
+Claude Codeは二層の分析パイプラインを実装し、広範な環境情報と使用メタデータを収集している。キーロギングやソースコード流出の証拠はないが、収集範囲の広さと完全な無効化が不可能な点にプライバシー上の懸念がある。
+
+## データパイプライン構成
+
+### ファーストパーティロギング（1P）
+
+- **エンドポイント**: `https://api.anthropic.com/api/event_logging/batch`
+- **プロトコル**: OpenTelemetry + Protocol Buffers
+- **バッチサイズ**: 最大200イベント、10秒間隔で送信
+- **リトライ**: 二次バックオフ、最大8回、ディスク永続化
+- **ストレージ**: 送信失敗時 `~/.claude/telemetry/` に保存
+
+出典: `src/services/analytics/firstPartyEventLoggingExporter.ts`
+
+### サードパーティロギング（Datadog）
+
+- **エンドポイント**: `https://http-intake.logs.us5.datadoghq.com/api/v2/logs`
+- **対象**: 事前承認済みの64種類のイベントに限定
+- **トークン**: `pubbbf48e6d78dae54bceaa4acf463299bf`
+
+出典: `src/services/analytics/datadog.ts`
+
+## 収集項目
+
+### 環境フィンガープリント
+
+すべてのイベントに以下のメタデータが含まれる（`src/services/analytics/metadata.ts:417-452`）:
+
+```
+- platform, platformRaw, arch, nodeVersion
+- ターミナル種別
+- インストール済みパッケージマネージャとランタイム
+- CI/CD検出、GitHub Actionsメタデータ
+- WSLバージョン、Linuxディストリビューション、カーネルバージョン
+- VCS（バージョン管理システム）種別
+- Claude Codeバージョンとビルド日時
+- デプロイ環境
+```
+
+### プロセスメトリクス（`metadata.ts:457-467`）
+
+```
+- uptime, rss, heapTotal, heapUsed
+- CPU使用量と使用率
+- memory arraysとexternal allocations
+```
+
+### ユーザー追跡（`metadata.ts:472-496`）
+
+```
+- 使用中のモデル
+- セッションID、ユーザーID、デバイスID
+- アカウントUUID、組織UUID
+- サブスクリプション等級（max, pro, enterprise, team）
+- リポジトリリモートURLハッシュ（SHA256、先頭16文字）
+- エージェント種別、チーム名、親セッションID
+```
+
+### ツール入力ロギング
+
+ツール入力はデフォルトで切り詰められる:
+
+```
+- 文字列: 512文字で切り詰め、128文字+省略記号で表示
+- JSON: 4,096文字制限
+- 配列: 最大20要素
+- ネストオブジェクト: 最大2階層
+```
+
+出典: `metadata.ts:236-241`
+
+ただし、`OTEL_LOG_TOOL_DETAILS=1` 設定時は**ツール入力がすべて記録される**。
+
+出典: `metadata.ts:86-88`
+
+### ファイル拡張子追跡
+
+`rm, mv, cp, touch, mkdir, chmod, chown, cat, head, tail, sort, stat, diff, wc, grep, rg, sed` 関連のBashコマンドで、ファイル引数の拡張子が抽出・記録される。
+
+出典: `metadata.ts:340-412`
+
+## 無効化の問題
+
+ファーストパーティロギングパイプラインは、直接Anthropic APIユーザーの場合**無効化できない**。
+
+```typescript
+// src/services/analytics/firstPartyEventLogger.ts:141-144
+export function is1PEventLoggingEnabled(): boolean {
+  return !isAnalyticsDisabled()
+}
+```
+
+`isAnalyticsDisabled()` がtrueを返すケース:
+- テスト環境
+- サードパーティクラウドプロバイダ（Bedrock, Vertex）
+- グローバルテレメトリ無効化（設定UIに非公開）
+
+ファーストパーティイベントロギングを無効化する**ユーザー向け設定は存在しない**。
+
+## GrowthBook A/Bテスト
+
+ユーザーは明示的な同意なくGrowthBookを通じて実験グループに割り当てられる。送信されるユーザー属性:
+
+```
+- id, sessionId, deviceID
+- platform, organizationUUID, subscriptionType
+```
+
+出典: `src/services/analytics/growthbook.ts`
+
+## 要点
+
+1. **収集量**: セッションあたり数百件のイベントが収集される
+2. **無効化不可**: 直接APIユーザーはファーストパーティロギングを停止できない
+3. **永続性**: 送信失敗イベントはディスクに保存され積極的にリトライされる
+4. **サードパーティ共有**: データがDatadogに送信される
+5. **ツール詳細バックドア**: `OTEL_LOG_TOOL_DETAILS=1` で全入力ロギングが有効化される
+6. **リポジトリフィンガープリント**: リポジトリURLがハッシュ化されサーバー側の相関分析に使用される

--- a/docs/ja/02-隠し機能とコードネーム.md
+++ b/docs/ja/02-隠し機能とコードネーム.md
@@ -1,0 +1,112 @@
+# 隠し機能とモデルコードネーム
+
+> Claude Code v2.1.88 デコンパイルソースコード分析に基づく。
+
+## モデルコードネーム体系
+
+Anthropicは内部モデルコードネームに**動物名**を使用している。外部ビルドへの漏洩を積極的に防止している。
+
+### 既知のコードネーム
+
+| コードネーム | 役割 | 根拠 |
+|-------------|------|------|
+| **Tengu**（天狗） | 製品/テレメトリ接頭辞、モデルの可能性あり | 250以上の分析イベントとfeature flagに `tengu_*` 接頭辞で使用 |
+| **Capybara**（カピバラ） | Sonnet系モデル、現在v8 | `capybara-v2-fast[1m]`、v8動作問題のパッチあり |
+| **Fennec**（フェネック） | Opus 4.6の前身モデル | マイグレーション: `fennec-latest` → `opus` |
+| **Numbat**（ナンバット） | 次期モデル | コメント: "Remove this section when we launch numbat" |
+
+### コードネーム保護
+
+`undercover` モードで保護対象コードネームが明示されている:
+
+```typescript
+// src/utils/undercover.ts:48-49
+NEVER include in commit messages or PR descriptions:
+- Internal model codenames (animal names like Capybara, Tengu, etc.)
+- Unreleased model version numbers (e.g., opus-4-7, sonnet-4-8)
+```
+
+ビルドシステムは `scripts/excluded-strings.txt` を使用してコードネームの漏洩を検出する。Buddyシステムの種（species）は `String.fromCharCode()` でエンコードし、カナリア検出を回避している:
+
+```typescript
+// src/buddy/types.ts:10-13
+// One species name collides with a model-codename canary in excluded-strings.txt.
+// The check greps build output (not source), so runtime-constructing the value keeps
+// the literal out of the bundle while the check stays armed for the actual codename.
+```
+
+衝突する種は **capybara** — ペットの種でありモデルコードネームでもある。
+
+### Capybara動作問題（v8）
+
+ソースコードからCapybara v8の具体的な動作問題が確認される:
+
+1. **Stop sequenceの誤発動**（プロンプト末尾に `<functions>` がある場合、約10%の発生率）
+   - 出典: `src/utils/messages.ts:2141`
+
+2. **空のtool_resultで出力ゼロ**
+   - 出典: `src/utils/toolResultStorage.ts:281`
+
+3. **コメント過剰挿入** — 専用コメント抑制プロンプトパッチが必要
+   - 出典: `src/constants/prompts.ts:204`
+
+4. **高い虚偽主張率**: v8は29-30%、v4は16.7%
+   - 出典: `src/constants/prompts.ts:237`
+
+5. **不十分な検証** — "徹底度カウンターウェイト（thoroughness counterweight）"が必要
+   - 出典: `src/constants/prompts.ts:210`
+
+## Feature Flag命名規則
+
+すべてのfeature flagは `tengu_` 接頭辞に**ランダムな単語ペア**を使用し、目的を難読化している:
+
+| Flag | 用途 |
+|------|------|
+| `tengu_onyx_plover` | Auto Dream（バックグラウンド記憶統合） |
+| `tengu_coral_fern` | memdir機能 |
+| `tengu_moth_copse` | memdir追加スイッチ |
+| `tengu_herring_clock` | Team memory |
+| `tengu_passport_quail` | Path機能 |
+| `tengu_slate_thimble` | memdir追加スイッチ |
+| `tengu_sedge_lantern` | Away Summary |
+| `tengu_frond_boric` | 分析キルスイッチ |
+| `tengu_amber_quartz_disabled` | 音声モードキルスイッチ |
+| `tengu_amber_flint` | Agent teams |
+| `tengu_hive_evidence` | 検証エージェント |
+
+ランダムな単語パターン（形容詞/素材 + 自然/物体）により、外部の観察者がflag名から機能の目的を推測することを防ぐ。
+
+## 内部ユーザーと外部ユーザーの違い
+
+Anthropic社員（`USER_TYPE === 'ant'`）は大幅に優遇されている:
+
+### プロンプトの違い（`src/constants/prompts.ts`）
+
+| 項目 | 外部ユーザー | 内部ユーザー（ant） |
+|------|------------|-------------------|
+| 出力スタイル | "Be extra concise"（極めて簡潔に） | "Err on the side of more explanation"（説明を多めに） |
+| 虚偽主張対策 | なし | 専用Capybara v8パッチ適用 |
+| 数値的長さ基準 | なし | "ツール間≤25単語、最終回答≤100単語" |
+| 検証エージェント | なし | 非自明な変更に必須 |
+| コメントガイド | 一般的 | 専用コメント過剰防止プロンプト |
+| 先制的修正 | なし | "ユーザーに誤解があれば指摘する" |
+
+### ツールアクセス
+
+内部ユーザーのみアクセス可能なツール:
+- `REPLTool` — REPLモード
+- `SuggestBackgroundPRTool` — バックグラウンドPR提案
+- `TungstenTool` — パフォーマンス監視パネル
+- `VerifyPlanExecutionTool` — 計画実行検証
+- Agent入れ子（エージェントがエージェントを生成）
+
+## 隠しコマンド
+
+| コマンド | 状態 | 説明 |
+|---------|------|------|
+| `/btw` | 有効 | 作業中断なしで余談質問 |
+| `/stickers` | 有効 | Claude Codeステッカー注文（ブラウザが開く） |
+| `/thinkback` | 有効 | 2025年振り返り |
+| `/effort` | 有効 | モデル努力レベル設定 |
+| `/good-claude` | スタブ | 隠しプレースホルダー |
+| `/bughunter` | スタブ | 隠しプレースホルダー |

--- a/docs/ja/03-アンダーカバーモード.md
+++ b/docs/ja/03-アンダーカバーモード.md
@@ -1,0 +1,110 @@
+# アンダーカバーモード分析
+
+> Claude Code v2.1.88 デコンパイルソースコード分析に基づく。
+
+## アンダーカバーモードとは
+
+アンダーカバーモードは、Anthropic社員が公開/オープンソースリポジトリにコントリビュートする際の安全システムである。有効化するとすべてのAI帰属表示を除去し、人間の開発者が書いたかのようにコントリビュートするようモデルに指示する。
+
+出典: `src/utils/undercover.ts`
+
+## 有効化条件
+
+```typescript
+// src/utils/undercover.ts:28-37
+export function isUndercover(): boolean {
+  if (process.env.USER_TYPE === 'ant') {
+    if (isEnvTruthy(process.env.CLAUDE_CODE_UNDERCOVER)) return true
+    // Auto: 内部リポジトリと確認されない限り自動有効化
+    return getRepoClassCached() !== 'internal'
+  }
+  return false
+}
+```
+
+主な特性:
+- **内部専用**: Anthropic社員（`USER_TYPE === 'ant'`）のみ対象
+- **デフォルト有効**: 内部許可リストにないすべてのリポジトリで自動有効化
+- **強制無効化不可**: "There is NO force-OFF. This guards against model codename leaks"
+- **外部ビルド**: バンドラーによりデッドコード除去され、実行されない
+
+## モデルに渡されるプロンプト
+
+```typescript
+// src/utils/undercover.ts:39-69
+export function getUndercoverInstructions(): string {
+  return `## UNDERCOVER MODE — CRITICAL
+
+You are operating UNDERCOVER in a PUBLIC/OPEN-SOURCE repository. Your commit
+messages, PR titles, and PR bodies MUST NOT contain ANY Anthropic-internal
+information. Do not blow your cover.
+
+NEVER include in commit messages or PR descriptions:
+- Internal model codenames (animal names like Capybara, Tengu, etc.)
+- Unreleased model version numbers (e.g., opus-4-7, sonnet-4-8)
+- Internal repo or project names (e.g., claude-cli-internal, anthropics/…)
+- Internal tooling, Slack channels, or short links (e.g., go/cc, #claude-code-…)
+- The phrase "Claude Code" or any mention that you are an AI
+- Any hint of what model or version you are
+- Co-Authored-By lines or any other attribution
+
+Write commit messages as a human developer would — describe only what the code
+change does.
+
+GOOD:
+- "Fix race condition in file watcher initialization"
+- "Add support for custom key bindings"
+
+BAD (never write these):
+- "Fix bug found while testing with Claude Capybara"
+- "1-shotted by claude-opus-4-6"
+- "Generated with Claude Code"
+- "Co-Authored-By: Claude Opus 4.6 <…>"`
+}
+```
+
+## 帰属表示システム
+
+帰属表示システム（`src/utils/attribution.ts`、`src/utils/commitAttribution.ts`）はアンダーカバーモードを補完する:
+
+```typescript
+// src/utils/attribution.ts:70-72
+// @[MODEL LAUNCH]: 以下のハードコードされたフォールバックモデル名を更新
+// （コードネーム漏洩防止用）。
+// 外部リポジトリでは、認識されないモデルは "Claude Opus 4.6" にフォールバック。
+```
+
+```typescript
+// src/utils/model/model.ts:386-392
+function maskModelCodename(baseName: string): string {
+  // e.g. capybara-v2-fast → cap*****-v2-fast
+  const [codename = '', ...rest] = baseName.split('-')
+  const masked = codename.slice(0, 3) + '*'.repeat(Math.max(0, codename.length - 3))
+  return [masked, ...rest].join('-')
+}
+```
+
+## 示唆
+
+### オープンソースへの影響
+
+Anthropic社員がClaude Codeでオープンソースプロジェクトにコントリビュートする場合:
+1. AIがコードを書くが、コミットは人間が書いたものとして表示される
+2. "Co-Authored-By: Claude"の帰属表示がない
+3. "Generated with Claude Code"のマーカーがない
+4. プロジェクトメンテナーやコミュニティはAI生成のコントリビュートを識別できない
+5. AIコントリビュートに関するオープンソースの透明性規範に抵触する可能性がある
+
+### Anthropicの保護目的
+
+主な目的は以下の偶発的漏洩の防止:
+- 内部モデルコードネーム（競争情報）
+- 未公開バージョン番号（市場タイミング）
+- 内部インフラの詳細（セキュリティ）
+
+### 倫理的考察
+
+"Do not blow your cover（正体を明かすな）"という表現はAIを潜入工作員として位置づけている。公開コードコントリビュートにおけるAI著作の意図的な隠匿は以下の問題を提起する:
+- オープンソースコミュニティにおける透明性
+- プロジェクトコントリビュートガイドラインの遵守
+- 営業秘密保護と欺瞞の境界線

--- a/docs/ja/04-リモート制御とキルスイッチ.md
+++ b/docs/ja/04-リモート制御とキルスイッチ.md
@@ -1,0 +1,161 @@
+# リモート制御およびキルスイッチ
+
+> Claude Code v2.1.88 デコンパイルソースコード分析に基づく。
+
+## 概要
+
+Claude Codeは、Anthropic（および企業管理者）がユーザーの明示的な同意なく動作を変更できる複数のリモート制御メカニズムを実装している。
+
+## 1. リモート管理設定
+
+### 構成
+
+対象セッションは以下から設定を取得する:
+```
+GET /api/claude_code/settings
+```
+
+出典: `src/services/remoteManagedSettings/index.ts:105-107`
+
+### ポーリング動作
+
+```typescript
+// src/services/remoteManagedSettings/index.ts:52-54
+const SETTINGS_TIMEOUT_MS = 10000
+const DEFAULT_MAX_RETRIES = 5
+const POLLING_INTERVAL_MS = 60 * 60 * 1000 // 1時間
+```
+
+設定は1時間ごとにポーリングされ、失敗時は最大5回リトライする。
+
+### 対象資格
+
+- Consoleユーザー（APIキー）: 全員対象
+- OAuthユーザー: Enterprise/C4EおよびTeamサブスクライバーのみ
+
+### 強制承認ダイアログ
+
+リモート設定に「危険な」変更が含まれる場合、ブロッキングダイアログが表示される:
+
+```typescript
+// src/services/remoteManagedSettings/securityCheck.tsx:67-73
+export function handleSecurityCheckResult(result: SecurityCheckResult): boolean {
+  if (result === 'rejected') {
+    gracefulShutdownSync(1)  // 終了コード1で終了
+    return false
+  }
+  return true
+}
+```
+
+リモート設定を拒否するとアプリケーションが**強制終了される**。選択肢はリモート設定の承認またはClaude Codeの終了のみである。
+
+### 障害時の動作
+
+リモートサーバーに接続できない場合、ディスクキャッシュ設定が使用される:
+
+```typescript
+// src/services/remoteManagedSettings/index.ts:433-436
+if (cachedSettings) {
+  logForDebugging('Remote settings: Using stale cache after fetch failure')
+  setSessionCache(cachedSettings)
+  return cachedSettings
+}
+```
+
+リモート設定が一度適用されると、サーバー障害時もキャッシュが維持される。
+
+## 2. Feature Flagキルスイッチ
+
+GrowthBook feature flagにより複数の機能をリモート無効化できる:
+
+### パーミッションバイパスキルスイッチ
+
+```typescript
+// src/utils/permissions/bypassPermissionsKillswitch.ts
+// Statsigゲートを確認してパーミッションバイパスを無効化
+```
+
+ユーザーの同意なくパーミッションバイパス機能を無効化できる。
+
+### Autoモードサーキットブレーカー
+
+```typescript
+// src/utils/permissions/autoModeState.ts
+// autoModeCircuitBroken状態でautoモードへの再突入を阻止
+```
+
+Autoモードをリモートで無効化できる。
+
+### Fastモードキルスイッチ
+
+```typescript
+// src/utils/fastMode.ts
+// /api/claude_code_penguin_mode から取得
+// 特定ユーザーのfastモードを永久に無効化可能
+```
+
+### 分析シンクキルスイッチ
+
+```typescript
+// src/services/analytics/sinkKillswitch.ts:4
+const SINK_KILLSWITCH_CONFIG_NAME = 'tengu_frond_boric'
+```
+
+すべての分析出力をリモートで停止できる。
+
+### Agent Teamsキルスイッチ
+
+```typescript
+// src/utils/agentSwarmsEnabled.ts
+// 環境変数とGrowthBookゲート 'tengu_amber_flint' の両方が必要
+```
+
+### 音声モードキルスイッチ
+
+```typescript
+// src/voice/voiceModeEnabled.ts:21
+// 'tengu_amber_quartz_disabled' — 音声モードの緊急停止
+```
+
+## 3. モデルオーバーライドシステム
+
+Anthropicは内部社員が使用するモデルをリモートで変更できる:
+
+```typescript
+// src/utils/model/antModels.ts:32-33
+// @[MODEL LAUNCH]: tengu_ant_model_overrideに新しいant専用モデルを更新
+// @[MODEL LAUNCH]: コードネームをscripts/excluded-strings.txtに追加
+```
+
+`tengu_ant_model_override` GrowthBook flagで可能な操作:
+- デフォルトモデルの設定
+- デフォルト努力レベルの設定
+- システムプロンプトへの内容追加
+- カスタムモデルエイリアスの定義
+
+## 4. Penguinモード
+
+Fastモードの状態は専用エンドポイントから取得される:
+
+```typescript
+// src/utils/fastMode.ts
+// GET /api/claude_code_penguin_mode
+// APIが無効を返した場合、該当ユーザーで永久無効化
+```
+
+Fastモードの可用性を制御するfeature flag:
+- `tengu_penguins_off`
+- `tengu_marble_sandcastle`
+
+## まとめ
+
+| メカニズム | 対象範囲 | ユーザー同意 |
+|-----------|---------|------------|
+| リモート管理設定 | Enterprise/Team | 承認または終了 |
+| GrowthBook feature flag | 全ユーザー | なし |
+| キルスイッチ | 全ユーザー | なし |
+| モデルオーバーライド | 内部（ant） | なし |
+| Fastモード制御 | 全ユーザー | なし |
+
+リモート制御インフラは広範であり、大部分がユーザーに不可視かつ同意なく運用されている。企業管理者はユーザーがオーバーライドできないポリシーを強制でき、Anthropicはfeature flagを通じてすべてのユーザーの動作をリモートで変更できる。

--- a/docs/ja/05-今後のロードマップ.md
+++ b/docs/ja/05-今後のロードマップ.md
@@ -1,0 +1,167 @@
+# 今後のロードマップ — ソースコードが示すもの
+
+> Claude Code v2.1.88 デコンパイルソースコード分析に基づく。
+
+## 1. 次期モデル: Numbat
+
+次期モデルリリースの最も具体的な根拠:
+
+```typescript
+// src/constants/prompts.ts:402
+// @[MODEL LAUNCH]: Remove this section when we launch numbat.
+```
+
+**Numbat**（ナンバット）は次期モデルのコードネームである。このコメントはNumbatリリース時に出力効率セクションが改訂されることを示しており、より優れたネイティブ出力制御を備える可能性を示唆している。
+
+### 今後のバージョン番号
+
+```typescript
+// src/utils/undercover.ts:49
+- Unreleased model version numbers (e.g., opus-4-7, sonnet-4-8)
+```
+
+**Opus 4.7** と **Sonnet 4.8** が開発中である。
+
+### コードネームの変遷
+
+```
+Fennec（フェネック） → Opus 4.6 → [Numbat?]
+Capybara（カピバラ） → Sonnet v8 → [?]
+Tengu（天狗） → テレメトリ/製品接頭辞
+```
+
+FennecからOpusへのマイグレーションが文書化されている:
+
+```typescript
+// src/migrations/migrateFennecToOpus.ts:7-11
+// fennec-latest → opus
+// fennec-latest[1m] → opus[1m]
+// fennec-fast-latest → opus[1m] + fast mode
+```
+
+### MODEL LAUNCHチェックリスト
+
+コードベースには更新項目を列挙した20以上の `@[MODEL LAUNCH]` マーカーがある:
+
+- デフォルトモデル名（`FRONTIER_MODEL_NAME`）
+- モデルファミリーID
+- ナレッジカットオフ日
+- 料金表
+- コンテキストウィンドウ設定
+- Thinkingモードサポートフラグ
+- 表示名マッピング
+- マイグレーションスクリプト
+
+## 2. KAIROS — 自律エージェントモード
+
+最大規模の未公開機能であり、KAIROSはClaude Codeを受動的アシスタントから能動的自律エージェントに変換する。
+
+### システムプロンプト（抜粋）
+
+```
+// src/constants/prompts.ts:860-913
+
+You are running autonomously.
+You will receive <tick> prompts that keep you alive between turns.
+If you have nothing useful to do, call SleepTool.
+Bias toward action — read files, make changes, commit without asking.
+
+## Terminal focus
+- Unfocused: The user is away. Lean heavily into autonomous action.
+- Focused: The user is watching. Be more collaborative.
+```
+
+### 関連ツール
+
+| ツール | Feature Flag | 用途 |
+|-------|-------------|------|
+| SleepTool | KAIROS / PROACTIVE | 自律動作間のペーシング制御 |
+| SendUserFileTool | KAIROS | ユーザーへのファイル先行送信 |
+| PushNotificationTool | KAIROS / KAIROS_PUSH_NOTIFICATION | ユーザーデバイスへのプッシュ通知 |
+| SubscribePRTool | KAIROS_GITHUB_WEBHOOKS | GitHub PRウェブフック購読 |
+| BriefTool | KAIROS_BRIEF | 先行ステータス更新 |
+
+### 動作方式
+
+- `<tick>` ハートビートプロンプトで稼働
+- ターミナルフォーカス状態に応じて自律レベルを調整
+- 独立してコミット、プッシュ、意思決定が可能
+- 先行的に通知とステータス更新を送信
+- GitHub PRの変更を監視
+
+## 3. 音声モード
+
+Push-to-talk音声入力が完全実装されているが `VOICE_MODE` feature flagでゲートされている。
+
+```typescript
+// src/voice/voiceModeEnabled.ts
+// Anthropicのvoice_stream WebSocketエンドポイントに接続
+// conversation_engineベースのモデルで音声テキスト変換
+// キーバインドを長押しで録音、離すと送信
+```
+
+- OAuth専用（APIキー / Bedrock / Vertex非対応）
+- WebSocket接続にmTLSを使用
+- キルスイッチ: `tengu_amber_quartz_disabled`
+
+## 4. 未公開ツール
+
+ソースに存在するが外部ユーザーにはまだ有効化されていないツール:
+
+| ツール | Feature Flag | 説明 |
+|-------|-------------|------|
+| **WebBrowserTool** | `WEB_BROWSER_TOOL` | 内蔵ブラウザ自動化（コードネーム: bagel） |
+| **TerminalCaptureTool** | `TERMINAL_PANEL` | ターミナルパネルキャプチャと監視 |
+| **WorkflowTool** | `WORKFLOW_SCRIPTS` | 定義済みワークフロースクリプト実行 |
+| **MonitorTool** | `MONITOR_TOOL` | システム/プロセス監視 |
+| **SnipTool** | `HISTORY_SNIP` | 会話履歴のスニッピング/縮小 |
+| **ListPeersTool** | `UDS_INBOX` | Unixドメインソケットピア探索 |
+| **RemoteTriggerTool** | `AGENT_TRIGGERS_REMOTE` | リモートエージェントトリガー |
+| **TungstenTool** | ant専用 | 内部パフォーマンス監視パネル |
+| **VerifyPlanExecutionTool** | VERIFY_PLAN env | 計画実行検証 |
+| **OverflowTestTool** | `OVERFLOW_TEST_TOOL` | コンテキストオーバーフローテスト |
+| **SubscribePRTool** | `KAIROS_GITHUB_WEBHOOKS` | GitHub PRウェブフック購読 |
+
+## 5. Coordinatorモード
+
+マルチエージェント連携システム:
+
+```typescript
+// src/coordinator/coordinatorMode.ts
+// Feature flag: COORDINATOR_MODE
+```
+
+共有状態とメッセージングによる複数エージェント間の連携タスク実行を実現する。
+
+## 6. Buddyシステム（バーチャルペット）
+
+完全なペットコンパニオンシステムが実装されているが未リリース:
+
+- **18種**: duck, goose, blob, cat, dragon, octopus, owl, penguin, turtle, snail, ghost, axolotl, capybara, cactus, robot, rabbit, mushroom, chonk
+- **5段階レアリティ**: Common (60%), Uncommon (25%), Rare (10%), Epic (4%), Legendary (1%)
+- **7種の帽子**: crown, tophat, propeller, halo, wizard, beanie, tinyduck
+- **5つのステータス**: DEBUGGING, PATIENCE, CHAOS, WISDOM, SNARK
+- **1%のシャイニー確率**: 全種のSparkleバリアント
+- **決定論的生成**: ユーザーIDハッシュに基づく
+
+出典: `src/buddy/`
+
+## 7. Dream Task
+
+バックグラウンド記憶統合サブエージェント:
+
+```
+// src/tasks/DreamTask/
+// バックグラウンドで動作するオートドリーミング機能
+// 'tengu_onyx_plover' feature flagで制御
+```
+
+アイドル時間中にAIが自律的に記憶を処理・統合できるようにする。
+
+## まとめ: 3つの方向性
+
+1. **新モデル**: Numbat（次期）、Opus 4.7、Sonnet 4.8が開発中
+2. **自律エージェント**: KAIROSモード — 無人運用、先行アクション、プッシュ通知
+3. **マルチモーダル**: 音声入力準備完了、ブラウザツール待機中、ワークフロー自動化予定
+
+Claude Codeは**コーディングアシスタント**から**常時稼働の自律開発エージェント**へと進化している。

--- a/docs/ko/01-텔레메트리와-프라이버시.md
+++ b/docs/ko/01-텔레메트리와-프라이버시.md
@@ -1,0 +1,124 @@
+# 텔레메트리 및 프라이버시 분석
+
+> Claude Code v2.1.88 디컴파일 소스 코드 분석 기반.
+
+## 개요
+
+Claude Code는 이중 분석 파이프라인을 통해 광범위한 환경 및 사용 메타데이터를 수집한다. 키로깅이나 소스 코드 유출의 증거는 없으나, 수집 범위가 넓고 완전한 비활성화가 불가능하다는 점에서 프라이버시 우려가 존재한다.
+
+## 데이터 파이프라인 구조
+
+### 자사 로깅 (1P)
+
+- **엔드포인트**: `https://api.anthropic.com/api/event_logging/batch`
+- **프로토콜**: OpenTelemetry + Protocol Buffers
+- **배치 크기**: 최대 200개 이벤트, 10초 간격 전송
+- **재시도**: 이차 백오프, 최대 8회, 디스크 영속 저장
+- **저장소**: 전송 실패 시 `~/.claude/telemetry/`에 저장
+
+출처: `src/services/analytics/firstPartyEventLoggingExporter.ts`
+
+### 서드파티 로깅 (Datadog)
+
+- **엔드포인트**: `https://http-intake.logs.us5.datadoghq.com/api/v2/logs`
+- **범위**: 사전 승인된 64개 이벤트 유형으로 제한
+- **토큰**: `pubbbf48e6d78dae54bceaa4acf463299bf`
+
+출처: `src/services/analytics/datadog.ts`
+
+## 수집 항목
+
+### 환경 핑거프린트
+
+모든 이벤트에 다음 메타데이터가 포함된다 (`src/services/analytics/metadata.ts:417-452`):
+
+```
+- platform, platformRaw, arch, nodeVersion
+- 터미널 유형
+- 설치된 패키지 매니저 및 런타임
+- CI/CD 감지, GitHub Actions 메타데이터
+- WSL 버전, Linux 배포판, 커널 버전
+- VCS(버전 관리 시스템) 유형
+- Claude Code 버전 및 빌드 시각
+- 배포 환경
+```
+
+### 프로세스 메트릭 (`metadata.ts:457-467`)
+
+```
+- uptime, rss, heapTotal, heapUsed
+- CPU 사용량 및 사용률
+- memory arrays 및 external allocations
+```
+
+### 사용자 추적 (`metadata.ts:472-496`)
+
+```
+- 사용 중인 모델
+- 세션 ID, 사용자 ID, 디바이스 ID
+- 계정 UUID, 조직 UUID
+- 구독 등급 (max, pro, enterprise, team)
+- 저장소 원격 URL 해시 (SHA256, 앞 16자)
+- 에이전트 유형, 팀 이름, 부모 세션 ID
+```
+
+### 도구 입력 로깅
+
+도구 입력은 기본적으로 잘린다:
+
+```
+- 문자열: 512자에서 잘림, 128자 + 생략부호로 표시
+- JSON: 4,096자 제한
+- 배열: 최대 20개 항목
+- 중첩 객체: 최대 2단계 깊이
+```
+
+출처: `metadata.ts:236-241`
+
+단, `OTEL_LOG_TOOL_DETAILS=1` 설정 시 **전체 도구 입력이 기록된다**.
+
+출처: `metadata.ts:86-88`
+
+### 파일 확장자 추적
+
+`rm, mv, cp, touch, mkdir, chmod, chown, cat, head, tail, sort, stat, diff, wc, grep, rg, sed` 관련 Bash 명령에서 파일 인자의 확장자가 추출·기록된다.
+
+출처: `metadata.ts:340-412`
+
+## 비활성화 문제
+
+자사 로깅 파이프라인은 직접 Anthropic API 사용자의 경우 **비활성화할 수 없다**.
+
+```typescript
+// src/services/analytics/firstPartyEventLogger.ts:141-144
+export function is1PEventLoggingEnabled(): boolean {
+  return !isAnalyticsDisabled()
+}
+```
+
+`isAnalyticsDisabled()`가 true를 반환하는 경우:
+- 테스트 환경
+- 서드파티 클라우드 제공자 (Bedrock, Vertex)
+- 글로벌 텔레메트리 비활성화 (설정 UI에 노출되지 않음)
+
+자사 이벤트 로깅을 비활성화하는 **사용자 대상 설정은 존재하지 않는다**.
+
+## GrowthBook A/B 테스트
+
+사용자는 명시적 동의 없이 GrowthBook을 통해 실험 그룹에 배정된다. 전송되는 사용자 속성:
+
+```
+- id, sessionId, deviceID
+- platform, organizationUUID, subscriptionType
+```
+
+출처: `src/services/analytics/growthbook.ts`
+
+## 핵심 요약
+
+1. **수집량**: 세션당 수백 건의 이벤트가 수집된다
+2. **비활성화 불가**: 직접 API 사용자는 자사 로깅을 끌 수 없다
+3. **영속성**: 전송 실패 이벤트는 디스크에 저장되어 적극적으로 재시도된다
+4. **서드파티 공유**: 데이터가 Datadog으로 전송된다
+5. **도구 상세 백도어**: `OTEL_LOG_TOOL_DETAILS=1`로 전체 입력 로깅이 활성화된다
+6. **저장소 핑거프린팅**: 저장소 URL이 해싱되어 서버 측 상관분석에 사용된다

--- a/docs/ko/02-숨겨진-기능과-코드네임.md
+++ b/docs/ko/02-숨겨진-기능과-코드네임.md
@@ -1,0 +1,112 @@
+# 숨겨진 기능과 모델 코드네임
+
+> Claude Code v2.1.88 디컴파일 소스 코드 분석 기반.
+
+## 모델 코드네임 체계
+
+Anthropic은 내부 모델 코드네임으로 **동물 이름**을 사용한다. 외부 빌드로의 유출을 적극적으로 차단하고 있다.
+
+### 알려진 코드네임
+
+| 코드네임 | 역할 | 근거 |
+|----------|------|------|
+| **Tengu** (천구) | 제품/텔레메트리 접두사, 모델일 가능성 있음 | 250개 이상의 분석 이벤트 및 feature flag에 `tengu_*` 접두사로 사용 |
+| **Capybara** (카피바라) | Sonnet 계열 모델, 현재 v8 | `capybara-v2-fast[1m]`, v8 동작 문제 패치 존재 |
+| **Fennec** (페넥여우) | Opus 4.6 이전 모델 | 마이그레이션: `fennec-latest` → `opus` |
+| **Numbat** (넘뱃) | 차기 모델 출시 예정 | 주석: "Remove this section when we launch numbat" |
+
+### 코드네임 보호
+
+`undercover` 모드에서 보호 대상 코드네임이 명시적으로 나열되어 있다:
+
+```typescript
+// src/utils/undercover.ts:48-49
+NEVER include in commit messages or PR descriptions:
+- Internal model codenames (animal names like Capybara, Tengu, etc.)
+- Unreleased model version numbers (e.g., opus-4-7, sonnet-4-8)
+```
+
+빌드 시스템은 `scripts/excluded-strings.txt`를 사용하여 유출된 코드네임을 검출한다. Buddy 시스템의 종(species)은 `String.fromCharCode()`로 인코딩하여 canary 검출을 우회한다:
+
+```typescript
+// src/buddy/types.ts:10-13
+// One species name collides with a model-codename canary in excluded-strings.txt.
+// The check greps build output (not source), so runtime-constructing the value keeps
+// the literal out of the bundle while the check stays armed for the actual codename.
+```
+
+충돌하는 종은 **capybara** — 펫 종이자 모델 코드네임이다.
+
+### Capybara 동작 이슈 (v8)
+
+소스 코드에서 Capybara v8의 구체적 동작 문제가 확인된다:
+
+1. **Stop sequence 오발동** (프롬프트 끝에 `<functions>` 있을 때 ~10% 발생)
+   - 출처: `src/utils/messages.ts:2141`
+
+2. **빈 tool_result 시 출력 없음**
+   - 출처: `src/utils/toolResultStorage.ts:281`
+
+3. **과도한 주석 삽입** — 전용 주석 방지 프롬프트 패치 필요
+   - 출처: `src/constants/prompts.ts:204`
+
+4. **높은 허위 주장 비율**: v8은 29-30%, v4는 16.7%
+   - 출처: `src/constants/prompts.ts:237`
+
+5. **불충분한 검증** — "철저함 보정값(thoroughness counterweight)" 필요
+   - 출처: `src/constants/prompts.ts:210`
+
+## Feature Flag 명명 규칙
+
+모든 feature flag는 `tengu_` 접두사에 **무작위 단어 조합**을 사용하여 목적을 난독화한다:
+
+| Flag | 용도 |
+|------|------|
+| `tengu_onyx_plover` | Auto Dream (백그라운드 기억 통합) |
+| `tengu_coral_fern` | memdir 기능 |
+| `tengu_moth_copse` | memdir 추가 스위치 |
+| `tengu_herring_clock` | Team memory |
+| `tengu_passport_quail` | Path 기능 |
+| `tengu_slate_thimble` | memdir 추가 스위치 |
+| `tengu_sedge_lantern` | Away Summary |
+| `tengu_frond_boric` | 분석 킬스위치 |
+| `tengu_amber_quartz_disabled` | 음성 모드 킬스위치 |
+| `tengu_amber_flint` | Agent teams |
+| `tengu_hive_evidence` | 검증 에이전트 |
+
+무작위 단어 패턴(형용사/재질 + 자연/사물)은 외부 관찰자가 flag 이름만으로 기능 목적을 추론하는 것을 방지한다.
+
+## 내부 사용자와 외부 사용자 차이
+
+Anthropic 직원(`USER_TYPE === 'ant'`)은 상당히 다른 대우를 받는다:
+
+### 프롬프트 차이 (`src/constants/prompts.ts`)
+
+| 항목 | 외부 사용자 | 내부 사용자 (ant) |
+|------|------------|------------------|
+| 출력 스타일 | "Be extra concise" (극도로 간결하게) | "Err on the side of more explanation" (설명을 더 하는 쪽으로) |
+| 허위 주장 대응 | 없음 | 전용 Capybara v8 패치 적용 |
+| 수치적 길이 기준 | 없음 | "도구 사이 ≤25단어, 최종 답변 ≤100단어" |
+| 검증 에이전트 | 없음 | 비자명한 변경에 필수 적용 |
+| 주석 가이드 | 일반적 | 전용 과잉 주석 방지 프롬프트 |
+| 선제적 교정 | 없음 | "사용자에게 오해가 있으면 지적" |
+
+### 도구 접근
+
+내부 사용자만 접근 가능한 도구:
+- `REPLTool` — REPL 모드
+- `SuggestBackgroundPRTool` — 백그라운드 PR 제안
+- `TungstenTool` — 성능 모니터링 패널
+- `VerifyPlanExecutionTool` — 계획 실행 검증
+- Agent 중첩 (에이전트가 에이전트를 생성)
+
+## 숨겨진 명령어
+
+| 명령어 | 상태 | 설명 |
+|--------|------|------|
+| `/btw` | 활성 | 작업 중단 없이 곁다리 질문 |
+| `/stickers` | 활성 | Claude Code 스티커 주문 (브라우저 열림) |
+| `/thinkback` | 활성 | 2025 연말 회고 |
+| `/effort` | 활성 | 모델 노력 수준 설정 |
+| `/good-claude` | 스텁 | 숨겨진 플레이스홀더 |
+| `/bughunter` | 스텁 | 숨겨진 플레이스홀더 |

--- a/docs/ko/03-언더커버-모드.md
+++ b/docs/ko/03-언더커버-모드.md
@@ -1,0 +1,110 @@
+# 언더커버 모드 분석
+
+> Claude Code v2.1.88 디컴파일 소스 코드 분석 기반.
+
+## 언더커버 모드란?
+
+언더커버 모드는 Anthropic 직원이 공개/오픈소스 저장소에 기여할 때 사용되는 안전 시스템이다. 활성화 시 모든 AI 저작 표시를 제거하고, 기여 내용을 사람이 작성한 것처럼 보이도록 모델에 지시한다.
+
+출처: `src/utils/undercover.ts`
+
+## 활성화 조건
+
+```typescript
+// src/utils/undercover.ts:28-37
+export function isUndercover(): boolean {
+  if (process.env.USER_TYPE === 'ant') {
+    if (isEnvTruthy(process.env.CLAUDE_CODE_UNDERCOVER)) return true
+    // Auto: 내부 저장소로 확인되지 않으면 자동 활성화
+    return getRepoClassCached() !== 'internal'
+  }
+  return false
+}
+```
+
+주요 특성:
+- **내부 전용**: Anthropic 직원(`USER_TYPE === 'ant'`)만 해당
+- **기본 활성화**: 내부 허용 목록에 없는 모든 저장소에서 자동 활성화
+- **강제 비활성화 불가**: "There is NO force-OFF. This guards against model codename leaks"
+- **외부 빌드**: 번들러에 의해 데드 코드 제거됨; 실행되지 않음
+
+## 모델에 전달되는 프롬프트
+
+```typescript
+// src/utils/undercover.ts:39-69
+export function getUndercoverInstructions(): string {
+  return `## UNDERCOVER MODE — CRITICAL
+
+You are operating UNDERCOVER in a PUBLIC/OPEN-SOURCE repository. Your commit
+messages, PR titles, and PR bodies MUST NOT contain ANY Anthropic-internal
+information. Do not blow your cover.
+
+NEVER include in commit messages or PR descriptions:
+- Internal model codenames (animal names like Capybara, Tengu, etc.)
+- Unreleased model version numbers (e.g., opus-4-7, sonnet-4-8)
+- Internal repo or project names (e.g., claude-cli-internal, anthropics/…)
+- Internal tooling, Slack channels, or short links (e.g., go/cc, #claude-code-…)
+- The phrase "Claude Code" or any mention that you are an AI
+- Any hint of what model or version you are
+- Co-Authored-By lines or any other attribution
+
+Write commit messages as a human developer would — describe only what the code
+change does.
+
+GOOD:
+- "Fix race condition in file watcher initialization"
+- "Add support for custom key bindings"
+
+BAD (never write these):
+- "Fix bug found while testing with Claude Capybara"
+- "1-shotted by claude-opus-4-6"
+- "Generated with Claude Code"
+- "Co-Authored-By: Claude Opus 4.6 <…>"`
+}
+```
+
+## 저작 표시 시스템
+
+저작 표시 시스템(`src/utils/attribution.ts`, `src/utils/commitAttribution.ts`)은 언더커버 모드를 보완한다:
+
+```typescript
+// src/utils/attribution.ts:70-72
+// @[MODEL LAUNCH]: 아래 하드코딩된 폴백 모델 이름 업데이트
+// (코드네임 유출 방지용).
+// 외부 저장소에서 인식되지 않는 모델은 "Claude Opus 4.6"으로 폴백.
+```
+
+```typescript
+// src/utils/model/model.ts:386-392
+function maskModelCodename(baseName: string): string {
+  // e.g. capybara-v2-fast → cap*****-v2-fast
+  const [codename = '', ...rest] = baseName.split('-')
+  const masked = codename.slice(0, 3) + '*'.repeat(Math.max(0, codename.length - 3))
+  return [masked, ...rest].join('-')
+}
+```
+
+## 시사점
+
+### 오픈소스에 대한 영향
+
+Anthropic 직원이 Claude Code로 오픈소스 프로젝트에 기여할 때:
+1. AI가 코드를 작성하지만 커밋은 사람이 작성한 것으로 표시된다
+2. "Co-Authored-By: Claude" 저작 표시가 없다
+3. "Generated with Claude Code" 마커가 없다
+4. 프로젝트 메인테이너와 커뮤니티는 AI 생성 기여를 식별할 수 없다
+5. 이는 AI 기여에 관한 오픈소스 투명성 규범을 잠재적으로 위반한다
+
+### Anthropic 보호 목적
+
+명시된 주요 목적은 다음의 우발적 유출 방지:
+- 내부 모델 코드네임 (경쟁 정보)
+- 미공개 버전 번호 (시장 타이밍)
+- 내부 인프라 세부 정보 (보안)
+
+### 윤리적 고려사항
+
+"Do not blow your cover(정체를 들키지 마라)"라는 표현은 AI를 잠입 요원으로 프레이밍한다. 공개 코드 기여에서의 의도적인 AI 저작 은폐는 다음과 같은 질문을 제기한다:
+- 오픈소스 커뮤니티에서의 투명성
+- 프로젝트 기여 가이드라인 준수 여부
+- 영업비밀 보호와 기만 사이의 경계

--- a/docs/ko/04-원격-제어와-킬스위치.md
+++ b/docs/ko/04-원격-제어와-킬스위치.md
@@ -1,0 +1,161 @@
+# 원격 제어 및 킬스위치
+
+> Claude Code v2.1.88 디컴파일 소스 코드 분석 기반.
+
+## 개요
+
+Claude Code는 Anthropic(및 기업 관리자)이 사용자의 명시적 동의 없이 동작을 변경할 수 있는 다수의 원격 제어 메커니즘을 구현하고 있다.
+
+## 1. 원격 관리 설정
+
+### 구조
+
+자격이 있는 모든 세션은 다음에서 설정을 가져온다:
+```
+GET /api/claude_code/settings
+```
+
+출처: `src/services/remoteManagedSettings/index.ts:105-107`
+
+### 폴링 동작
+
+```typescript
+// src/services/remoteManagedSettings/index.ts:52-54
+const SETTINGS_TIMEOUT_MS = 10000
+const DEFAULT_MAX_RETRIES = 5
+const POLLING_INTERVAL_MS = 60 * 60 * 1000 // 1시간
+```
+
+설정은 1시간마다 폴링되며, 실패 시 최대 5회 재시도한다.
+
+### 대상 자격
+
+- Console 사용자 (API 키): 전원 대상
+- OAuth 사용자: Enterprise/C4E 및 Team 구독자만 해당
+
+### 수락 강제 다이얼로그
+
+원격 설정에 "위험한" 변경이 포함되면 차단 다이얼로그가 표시된다:
+
+```typescript
+// src/services/remoteManagedSettings/securityCheck.tsx:67-73
+export function handleSecurityCheckResult(result: SecurityCheckResult): boolean {
+  if (result === 'rejected') {
+    gracefulShutdownSync(1)  // 종료 코드 1로 종료
+    return false
+  }
+  return true
+}
+```
+
+원격 설정을 거부하면 애플리케이션이 **강제 종료된다**. 선택지는 원격 설정 수락 또는 Claude Code 종료뿐이다.
+
+### 장애 시 동작
+
+원격 서버 접근이 불가능하면 디스크 캐시 설정을 사용한다:
+
+```typescript
+// src/services/remoteManagedSettings/index.ts:433-436
+if (cachedSettings) {
+  logForDebugging('Remote settings: Using stale cache after fetch failure')
+  setSessionCache(cachedSettings)
+  return cachedSettings
+}
+```
+
+원격 설정이 한 번 적용되면, 서버 장애 시에도 캐시가 유지된다.
+
+## 2. Feature Flag 킬스위치
+
+GrowthBook feature flag를 통해 여러 기능을 원격 비활성화할 수 있다:
+
+### 권한 우회 킬스위치
+
+```typescript
+// src/utils/permissions/bypassPermissionsKillswitch.ts
+// Statsig 게이트를 확인하여 권한 우회를 비활성화
+```
+
+사용자 동의 없이 권한 우회 기능을 비활성화할 수 있다.
+
+### Auto 모드 서킷 브레이커
+
+```typescript
+// src/utils/permissions/autoModeState.ts
+// autoModeCircuitBroken 상태로 auto 모드 재진입을 차단
+```
+
+Auto 모드를 원격으로 비활성화할 수 있다.
+
+### Fast 모드 킬스위치
+
+```typescript
+// src/utils/fastMode.ts
+// /api/claude_code_penguin_mode 에서 조회
+// 특정 사용자의 fast 모드를 영구 비활성화 가능
+```
+
+### 분석 싱크 킬스위치
+
+```typescript
+// src/services/analytics/sinkKillswitch.ts:4
+const SINK_KILLSWITCH_CONFIG_NAME = 'tengu_frond_boric'
+```
+
+모든 분석 출력을 원격으로 중단할 수 있다.
+
+### Agent Teams 킬스위치
+
+```typescript
+// src/utils/agentSwarmsEnabled.ts
+// 환경 변수와 GrowthBook 게이트 'tengu_amber_flint' 모두 필요
+```
+
+### 음성 모드 킬스위치
+
+```typescript
+// src/voice/voiceModeEnabled.ts:21
+// 'tengu_amber_quartz_disabled' — 음성 모드 긴급 차단
+```
+
+## 3. 모델 오버라이드 시스템
+
+Anthropic은 내부 직원이 사용하는 모델을 원격으로 변경할 수 있다:
+
+```typescript
+// src/utils/model/antModels.ts:32-33
+// @[MODEL LAUNCH]: tengu_ant_model_override에 새 ant 전용 모델 업데이트
+// @[MODEL LAUNCH]: 코드네임을 scripts/excluded-strings.txt에 추가
+```
+
+`tengu_ant_model_override` GrowthBook flag로 가능한 작업:
+- 기본 모델 설정
+- 기본 노력 수준 설정
+- 시스템 프롬프트에 내용 추가
+- 커스텀 모델 별칭 정의
+
+## 4. Penguin 모드
+
+Fast 모드 상태는 전용 엔드포인트에서 조회한다:
+
+```typescript
+// src/utils/fastMode.ts
+// GET /api/claude_code_penguin_mode
+// API가 비활성화를 응답하면 해당 사용자에게 영구 비활성화
+```
+
+Fast 모드 가용성을 제어하는 feature flag:
+- `tengu_penguins_off`
+- `tengu_marble_sandcastle`
+
+## 요약
+
+| 메커니즘 | 범위 | 사용자 동의 |
+|----------|------|------------|
+| 원격 관리 설정 | Enterprise/Team | 수락 또는 종료 |
+| GrowthBook feature flag | 전체 사용자 | 없음 |
+| 킬스위치 | 전체 사용자 | 없음 |
+| 모델 오버라이드 | 내부 (ant) | 없음 |
+| Fast 모드 제어 | 전체 사용자 | 없음 |
+
+원격 제어 인프라는 광범위하며, 대부분 사용자에게 보이지 않고 동의 없이 운영된다. 기업 관리자는 사용자가 재정의할 수 없는 정책을 강제할 수 있고, Anthropic은 feature flag를 통해 모든 사용자의 동작을 원격으로 변경할 수 있다.

--- a/docs/ko/05-향후-로드맵.md
+++ b/docs/ko/05-향후-로드맵.md
@@ -1,0 +1,167 @@
+# 향후 로드맵 — 소스 코드에서 드러난 내용
+
+> Claude Code v2.1.88 디컴파일 소스 코드 분석 기반.
+
+## 1. 차기 모델: Numbat
+
+차기 모델 출시의 가장 구체적인 근거:
+
+```typescript
+// src/constants/prompts.ts:402
+// @[MODEL LAUNCH]: Remove this section when we launch numbat.
+```
+
+**Numbat**(넘뱃)은 차기 모델의 코드네임이다. 이 주석은 Numbat 출시 시 출력 효율성 섹션이 개정될 것임을 나타내며, 더 나은 네이티브 출력 제어를 갖출 가능성을 시사한다.
+
+### 향후 버전 번호
+
+```typescript
+// src/utils/undercover.ts:49
+- Unreleased model version numbers (e.g., opus-4-7, sonnet-4-8)
+```
+
+**Opus 4.7**과 **Sonnet 4.8**이 개발 중이다.
+
+### 코드네임 변천
+
+```
+Fennec (페넥여우) → Opus 4.6 → [Numbat?]
+Capybara (카피바라) → Sonnet v8 → [?]
+Tengu (천구) → 텔레메트리/제품 접두사
+```
+
+Fennec에서 Opus로의 마이그레이션이 문서화되어 있다:
+
+```typescript
+// src/migrations/migrateFennecToOpus.ts:7-11
+// fennec-latest → opus
+// fennec-latest[1m] → opus[1m]
+// fennec-fast-latest → opus[1m] + fast mode
+```
+
+### MODEL LAUNCH 체크리스트
+
+코드베이스에는 업데이트할 항목을 나열한 20개 이상의 `@[MODEL LAUNCH]` 마커가 있다:
+
+- 기본 모델 이름 (`FRONTIER_MODEL_NAME`)
+- 모델 패밀리 ID
+- 지식 기준일(knowledge cutoff)
+- 가격표
+- 컨텍스트 윈도우 설정
+- Thinking 모드 지원 플래그
+- 표시 이름 매핑
+- 마이그레이션 스크립트
+
+## 2. KAIROS — 자율 에이전트 모드
+
+최대 규모의 미공개 기능으로, KAIROS는 Claude Code를 반응형 어시스턴트에서 능동적 자율 에이전트로 변환한다.
+
+### 시스템 프롬프트 (발췌)
+
+```
+// src/constants/prompts.ts:860-913
+
+You are running autonomously.
+You will receive <tick> prompts that keep you alive between turns.
+If you have nothing useful to do, call SleepTool.
+Bias toward action — read files, make changes, commit without asking.
+
+## Terminal focus
+- Unfocused: The user is away. Lean heavily into autonomous action.
+- Focused: The user is watching. Be more collaborative.
+```
+
+### 관련 도구
+
+| 도구 | Feature Flag | 용도 |
+|------|-------------|------|
+| SleepTool | KAIROS / PROACTIVE | 자율 동작 간 페이싱 제어 |
+| SendUserFileTool | KAIROS | 사용자에게 파일 선제 전송 |
+| PushNotificationTool | KAIROS / KAIROS_PUSH_NOTIFICATION | 사용자 기기에 푸시 알림 |
+| SubscribePRTool | KAIROS_GITHUB_WEBHOOKS | GitHub PR 웹훅 이벤트 구독 |
+| BriefTool | KAIROS_BRIEF | 선제적 상태 업데이트 |
+
+### 동작 방식
+
+- `<tick>` 하트비트 프롬프트로 작동
+- 터미널 포커스 상태에 따라 자율성 수준 조정
+- 독립적으로 커밋, 푸시, 의사결정 가능
+- 선제적 알림 및 상태 업데이트 전송
+- GitHub PR 변경사항 모니터링
+
+## 3. 음성 모드
+
+Push-to-talk 음성 입력이 완전 구현되어 있으나 `VOICE_MODE` feature flag로 차단되어 있다.
+
+```typescript
+// src/voice/voiceModeEnabled.ts
+// Anthropic의 voice_stream WebSocket 엔드포인트에 연결
+// conversation_engine 기반 모델로 음성-텍스트 변환
+// 키 바인딩을 길게 눌러 녹음, 놓으면 전송
+```
+
+- OAuth 전용 (API 키 / Bedrock / Vertex 미지원)
+- WebSocket 연결에 mTLS 사용
+- 킬스위치: `tengu_amber_quartz_disabled`
+
+## 4. 미공개 도구
+
+소스에 존재하지만 외부 사용자에게 아직 활성화되지 않은 도구:
+
+| 도구 | Feature Flag | 설명 |
+|------|-------------|------|
+| **WebBrowserTool** | `WEB_BROWSER_TOOL` | 내장 브라우저 자동화 (코드네임: bagel) |
+| **TerminalCaptureTool** | `TERMINAL_PANEL` | 터미널 패널 캡처 및 모니터링 |
+| **WorkflowTool** | `WORKFLOW_SCRIPTS` | 사전 정의된 워크플로우 스크립트 실행 |
+| **MonitorTool** | `MONITOR_TOOL` | 시스템/프로세스 모니터링 |
+| **SnipTool** | `HISTORY_SNIP` | 대화 히스토리 잘라내기/축소 |
+| **ListPeersTool** | `UDS_INBOX` | Unix 도메인 소켓 피어 탐색 |
+| **RemoteTriggerTool** | `AGENT_TRIGGERS_REMOTE` | 원격 에이전트 트리거 |
+| **TungstenTool** | ant 전용 | 내부 성능 모니터링 패널 |
+| **VerifyPlanExecutionTool** | VERIFY_PLAN env | 계획 실행 검증 |
+| **OverflowTestTool** | `OVERFLOW_TEST_TOOL` | 컨텍스트 오버플로우 테스트 |
+| **SubscribePRTool** | `KAIROS_GITHUB_WEBHOOKS` | GitHub PR 웹훅 구독 |
+
+## 5. Coordinator 모드
+
+멀티 에이전트 조율 시스템:
+
+```typescript
+// src/coordinator/coordinatorMode.ts
+// Feature flag: COORDINATOR_MODE
+```
+
+공유 상태와 메시징을 통한 다수 에이전트 간 조율된 작업 실행을 지원한다.
+
+## 6. Buddy 시스템 (가상 펫)
+
+완전한 펫 동반자 시스템이 구현되어 있으나 아직 출시되지 않았다:
+
+- **18종**: duck, goose, blob, cat, dragon, octopus, owl, penguin, turtle, snail, ghost, axolotl, capybara, cactus, robot, rabbit, mushroom, chonk
+- **5단계 희귀도**: Common (60%), Uncommon (25%), Rare (10%), Epic (4%), Legendary (1%)
+- **7종 모자**: crown, tophat, propeller, halo, wizard, beanie, tinyduck
+- **5가지 스탯**: DEBUGGING, PATIENCE, CHAOS, WISDOM, SNARK
+- **1% 반짝이 확률**: 모든 종의 Sparkle 변형
+- **결정론적 생성**: 사용자 ID 해시 기반
+
+출처: `src/buddy/`
+
+## 7. Dream Task
+
+백그라운드 기억 통합 서브에이전트:
+
+```
+// src/tasks/DreamTask/
+// 백그라운드에서 동작하는 자동 드리밍 기능
+// 'tengu_onyx_plover' feature flag로 제어
+```
+
+유휴 시간 중 AI가 자율적으로 기억을 처리하고 통합할 수 있게 한다.
+
+## 요약: 세 가지 방향
+
+1. **신규 모델**: Numbat (차기), Opus 4.7, Sonnet 4.8 개발 중
+2. **자율 에이전트**: KAIROS 모드 — 무인 운영, 선제적 행동, 푸시 알림
+3. **멀티모달**: 음성 입력 준비 완료, 브라우저 도구 대기 중, 워크플로우 자동화 예정
+
+Claude Code는 **코딩 어시스턴트**에서 **상시 가동 자율 개발 에이전트**로 진화하고 있다.


### PR DESCRIPTION
## Summary                                                                                                                                         
  - Add Korean (ko) and Japanese (ja) translations for all 5 analysis docs                                                                           
  - Add README_KR.md and README_JA.md with full translated content                                                                                   
  - Update language navigation links across all READMEs (EN/ZH/KO/JA)                                                                                
  - Update docs description from "Bilingual" to "Quadrilingual"                                                                                      
                                                                                                                                                     
  ## Changes                                                                                                                                         
  - New: `docs/ko/` - 5 Korean translation files                                                                                                     
  - New: `docs/ja/` - 5 Japanese translation files                                                                                                   
  - New: `README_KR.md`, `README_JA.md`                                                                                                              
  - Modified: `README.md`, `README_CN.md` - added language links and ja/ko directory tree           